### PR TITLE
Make bastion slaves exclusive

### DIFF
--- a/jobs/templates/installation-pipeline.yaml
+++ b/jobs/templates/installation-pipeline.yaml
@@ -96,7 +96,7 @@
                       agent.nodeDescription = "Bastion for ${JOB_NAME}"
                       agent.numExecutors = 1
                       agent.labelString = bastionLabel
-                      agent.mode = Node.Mode.NORMAL
+                      agent.mode = Node.Mode.EXCLUSIVE
                       agent.retentionStrategy = new RetentionStrategy.Always()
           
                       // Create a "Permanent Agent"


### PR DESCRIPTION
*Motivation*

Exclusive slaves are only assigned for builds if the build explicitly asks for such slave using label. We don't want other builds apart from installation pipeline for specific cluster hidden behind the bastion to be executed on that bastion slave.

https://javadoc.jenkins.io/hudson/model/Node.html#getMode--