### PR TITLE
Added job for browser testsuite

### DIFF
--- a/jobs/templates/browser-based-testsuite-pipeline.yaml
+++ b/jobs/templates/browser-based-testsuite-pipeline.yaml
@@ -1,0 +1,71 @@
+---
+
+- job:
+    name: browser-based-testsuite-pipeline
+    project-type: pipeline
+    description: 'Executes browser based testsuite against Integreatly Tutorial Web App.'
+    sandbox: false
+    parameters:
+      - string:
+          name: REPOSITORY
+          description: 'Repository of the Integreatly Browser based tests'
+      - string:
+          name: BRANCH
+          default: 'master'
+          description: 'Branch of the repository'
+      - string:
+          name: WEBAPP_URL
+          description: 'URL of Tutorial Web App'
+      - string:
+          name: ADMIN_USERNAME
+          default: 'admin@example.com'
+          description: 'Username for Tutorial Web App log in'
+      - string:
+          name: ADMIN_PASSWORD
+          default: 'Password1'
+          description: 'Password for the Tutorial Web App log in'
+    dsl: |
+      timeout(60) {
+          node('cirhos_rhel7') {  
+              stage('Clone the testsuite') {
+                  dir('integreatly-qe') {
+                      git branch: BRANCH, url: REPOSITORY
+                  } // dir
+              } // stage
+              
+              stage('Start browser container') {
+                  sh """                          
+                      sudo docker run --name chrome_selenium -d -p 4444:4444 -v /dev/shm:/dev/shm -v "$PWD":"$PWD" -e SE_OPTS="-timeout 3600" selenium/standalone-chrome:3.14.0-krypton || true
+                  """
+              }
+
+              stage('Initial setup') {
+                  dir('integreatly-qe/js-testsuite') {
+                      sh """
+                          # Disable starting Selenium, Docker is used instead
+                          sed -i 's/"start_process" : true,/"start_process" : false,/g' nightwatch.json
+                          npm install
+                      """
+                  } // dir
+              }
+              
+              stage('Execute tests') {
+                  dir('integreatly-qe/js-testsuite') {
+                      sh """
+                          export WEBAPP_URL=${WEBAPP_URL}
+                          export ADMIN_USERNAME=${ADMIN_USERNAME}
+                          export ADMIN_PASSWORD=${ADMIN_PASSWORD}
+
+                          npm test
+                      """
+                  } // dir
+              } // stage
+              
+              stage('Stop browser container') {
+                  sh """
+                      sudo docker stop chrome_selenium || true
+                      sudo docker rm chrome_selenium || true
+                  """
+              } // stage
+          } // node
+      } // timeout


### PR DESCRIPTION
*Motivation*

Added job definition for browser based test suite. Once done we can add this into our nightly pipeline.

*To Test*

`jenkins-jobs --conf jenkins_jobs.ini update jobs/templates/browser-based-testsuite-pipeline.yaml`

Job based on this definition has already been created
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/browser-based-testsuite-pipeline/