### PR TITLE
Increased number of executors

### DIFF
--- a/jobs/templates/installation-pipeline.yaml
+++ b/jobs/templates/installation-pipeline.yaml
@@ -94,7 +94,7 @@
                               "/home/${BASTION_USER}",
                               launcher)
                       agent.nodeDescription = "Bastion for ${JOB_NAME}"
-                      agent.numExecutors = 1
+                      agent.numExecutors = 3
                       agent.labelString = bastionLabel
                       agent.mode = Node.Mode.EXCLUSIVE
                       agent.retentionStrategy = new RetentionStrategy.Always()

--- a/jobs/templates/uninstallation-pipeline.yaml
+++ b/jobs/templates/uninstallation-pipeline.yaml
@@ -80,7 +80,7 @@
                               "/home/${BASTION_USER}",
                               launcher)
                       agent.nodeDescription = "Bastion for ${JOB_NAME}"
-                      agent.numExecutors = 1
+                      agent.numExecutors = 3
                       agent.labelString = bastionLabel
                       agent.mode = Node.Mode.EXCLUSIVE
                       agent.retentionStrategy = new RetentionStrategy.Always()


### PR DESCRIPTION
## Motivation
In case of some workaround is required (eg using oc to manually remove some resource until uninstall playbook is fixed) we need to run the nightly pipeline on bastion directly (cannot use cirhos-rhel7 because the oc commands (the workaround) only works no bastion slave)

## What
In order to run more stages/build steps of the pipeline on the same bastion slave we need to increase tne number of executors on that slave.

## Why
See motivation.

## How
Increased the number of executors to 3.

## Verification Steps
Remove the pastion slave, run the pipeline again (so it re-creates it), and see that there are three executors (see Build Executor Status in Jenkins landing page).

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
