### PR TITLE
browser-based-pipeline set build result as unstable when there's a te…

### DIFF
--- a/scripts/browser-tests.groovy
+++ b/scripts/browser-tests.groovy
@@ -13,8 +13,12 @@ timeout(60) {
                       # Disable starting Selenium, Docker is used instead
                       sed -i 's/"start_process" : true,/"start_process" : false,/g' nightwatch.json
                       npm install
-                      npm test
                     """
+                    try {
+                        sh "npm test"
+                    } catch (exp) {
+                        currentBuild.result = 'UNSTABLE'
+                    }
                 } 
             }
         }


### PR DESCRIPTION
…st failure

## Motivation
Mark a build result as unstable instead of failure when there is some test failure

## What
Add try/catch block for "npm test" command and set build result in the catch block

## Why
<!-- Add a short answer for: Why it was done? (E.g The feature X was deprecated.) -->

## How
## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->
