### PR TITLE
Added CLUSTER_URL param to browser tests

### DIFF
--- a/jobs/templates/testing/browser-based-testsuite-pipeline.yaml
+++ b/jobs/templates/testing/browser-based-testsuite-pipeline.yaml
@@ -26,6 +26,9 @@
           name: WEBAPP_URL
           description: 'URL of Tutorial Web App'
       - string:
+          name: CLUSTER_URL
+          description: 'URL of OpenShift Cluster'
+      - string:
           name: ADMIN_USERNAME
           default: 'admin@example.com'
           description: 'Username for Tutorial Web App log in'


### PR DESCRIPTION
## Motivation
Our test has been changed (CLUSTER_URL param has been added) thus we need to update the JJB template accordingly

## What
Add the CLUSTER_URL param

## Why
See motivation

## How
Updating template to contain newly introduced param.

## Verification Steps
jenkins-jobs --conf jenkins_jobs.ini test jobs/templates/testing/browser-based-testsuite-pipeline.yaml

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

## Additional Notes

The job in jenkins has already been updated accordingly.