### PR TITLE
Allow concurrency in (un)installation pipelines

### DIFF
--- a/jobs/integr8ly/installation-pipeline.yaml
+++ b/jobs/integr8ly/installation-pipeline.yaml
@@ -5,6 +5,7 @@
     project-type: pipeline
     description: "Installs Integreatly by using bastion server as Jenkins slave and executing Ansible installation playbook there."
     sandbox: false
+    concurrent: true
     parameters:
         - string:
             name: REPOSITORY

--- a/jobs/integr8ly/uninstallation-pipeline.yaml
+++ b/jobs/integr8ly/uninstallation-pipeline.yaml
@@ -5,6 +5,7 @@
     project-type: pipeline
     description: "Uninstalls Integreatly by using bastion server as Jenkins slave and executing Ansible uninstallation playbook there."
     sandbox: false
+    concurrent: true
     parameters:
         - string:
             name: REPOSITORY


### PR DESCRIPTION
## Motivation
To allow multiple users leverage installation and uninstall pipelines.

## What
Just adding `concurrent: true`