### PR TITLE
release monitoring job

### DIFF
--- a/jobs/release-monitoring/release-monitoring-github/Jenkinsfile
+++ b/jobs/release-monitoring/release-monitoring-github/Jenkinsfile
@@ -1,0 +1,201 @@
+#!groovy
+
+//remote repository checkout
+def checkoutGitRepo(gitUrl, gitRef, credentialsID) {
+    checkout([$class: 'GitSCM', branches: [[name: gitRef]],
+            doGenerateSubmoduleConfigurations: false,
+            extensions: [],
+            submoduleCfg: [],
+            userRemoteConfigs: [[credentialsId: credentialsID, url: gitUrl]]])
+}
+
+//gets latest release tag of a github repository
+def getLatestRelease(gitOrg, gitRepo, gitTokenId) {
+    def response = null
+    def data = null
+    
+    withCredentials([string(credentialsId: gitTokenId, variable: 'gitToken')]) {
+        def url = "https://api.github.com/repos/${gitOrg}/${gitRepo}/releases/latest"
+        def headers = [
+            ["name": "Authorization", "value": "token ${env.gitToken}"]
+        ]
+
+        response = httpRequest customHeaders: headers, url: url
+        data = readJSON text: response.content
+    }
+
+    return [response.status, data]
+}
+
+def getLabelScore(label) {
+    if (!label) {
+        return 0
+    }
+    
+    def score = 0
+    def scores = [
+        'GA': 1,
+        'redhat': 1
+    ]
+    def parts = label.tokenize('-')
+    
+    parts.each { part ->
+        if (scores.containsKey(part)) {
+            score += scores[part]
+        }
+
+        if (!scores.containsKey(part) && part.isInteger()) {
+            score += part.toInteger()
+        }
+    }
+
+    return score
+}
+
+//checks if current semver is lower than the supposed latest one
+def hasNewGARelease(currentVersion, newVersion) {
+    def current = currentVersion.tokenize('.')
+    def latest = newVersion.tokenize('.')
+
+    def currentMajor = current[0] as Integer
+    def latestMajor = latest[0] as Integer
+    def currentMinor = current[1] as Integer
+    def latestMinor = latest[1] as Integer
+    def currentPatch = current[2] as Integer
+    def latestPatch = latest[2] as Integer
+    def currentLabel = current[3]
+    def latestLabel = latest[3]
+
+    def previousVer = 0
+    def currentVer = 0
+    for (i = 0; i <= 2; i++) {
+        if (i > 0) {
+            previousVer = i - 1
+        }
+        currentVer = i
+
+        def previousDiff = current[previousVer] == latest[previousVer]
+        if (i == 0) {
+            previousDiff = true
+        }
+        def currentDiff =  latest[currentVer] > current[currentVer]
+        if (previousDiff && currentDiff) {
+            return true
+        }
+    }
+
+    def currentLabelScore = getLabelScore(currentLabel)
+    def latestLabelScore = getLabelScore(latestLabel)
+
+    if (latestLabelScore > currentLabelScore) {
+        return true
+    }
+
+    return false
+}
+
+def fnMap = [
+    '3scale': { currentVersion, newVersion -> hasNewGARelease(currentVersion, newVersion) }
+]
+
+def installationGitUrl = params.installationGitUrl
+def installationGitRef = params.installationGitRef
+def manifestVar = params.manifestVar
+def projectOrg = params.projectOrg
+def projectRepo = params.projectRepo
+def githubToken = params.githubToken
+def githubCredentialsID = params.credentialId
+def nextBranch = params.installationProductBranch
+def clusterConfigCredentialsID = params.clusterConfigCredentialsID
+def dryRun = params.dryRun
+def installJobName = params.installJobName
+def testJobName = params.testJobName
+def uninstallJobName = params.uninstallJobName
+def productName = params.productName
+
+node {
+    stage('Fetch Installation Repo') {
+        println '[INFO] Fetch Installation Repo'
+
+        cleanWs()
+        dir('installation') {
+            checkoutGitRepo(installationGitUrl, installationGitRef, githubCredentialsID)
+            releaseConfig = readYaml file: './evals/inventories/group_vars/all/manifest.yaml'
+            componentRelease = releaseConfig[manifestVar]
+        }
+    }
+
+    stage('Fetch latest release') {
+        def (code, data) = getLatestRelease(projectOrg, projectRepo, githubToken)
+        if (code != 200) {
+            currentBuild.result = "FAILURE"
+            error "[ERROR] Failed to retrieved latest release: ${data}"
+        }
+        def tagName = data.tag_name
+        latestRelease = tagName
+    }
+
+    stage('Diff Release Versions') {
+        if (latestRelease == "" || componentRelease == "") {
+            currentBuild.result = "FAILURE"
+            error "[ERROR] Error while retrieving releases: ${latestRelease}:${componentRelease}"
+        }
+
+        def checkFn = fnMap[productName]
+        if (!checkFn) {
+            currentBuild.result = "FAILURE"
+            error "[ERROR] Could not find a function to check this product version"
+        }
+
+        if (!checkFn(componentRelease, latestRelease)) {
+            currentBuild.result = "ABORTED"
+            error '[ERROR] No new releases available'
+        }
+
+        println '[INFO] Found new release'
+
+        releaseConfig[manifestVar] = latestRelease
+        dir('installation') {
+            sshagent([githubCredentialsID]) {
+                sh 'git config --global user.name "Automatron"'
+                sh 'git config --global user.email "github.eng@feedhenry.com"'
+                
+                def branchCode = sh script: "git checkout -b ${nextBranch}", returnStatus: true
+                if (branchCode  != 0) {
+                    sh "git checkout ${nextBranch}"
+                    sh "git fetch origin && git reset --hard origin/${nextBranch}"
+                }
+                
+                sh "git rebase origin/${installationGitRef}"
+
+                sh 'rm ./evals/inventories/group_vars/all/manifest.yaml'
+                writeYaml file: './evals/inventories/group_vars/all/manifest.yaml', data: releaseConfig
+                sh 'git add ./evals/inventories/group_vars/all/manifest.yaml'
+
+                def changesCode = sh script: "git diff --exit-code ./evals/inventories/group_vars/all/manifest.yaml", returnStatus: true
+                if (branchCode != 0 && changesCode == 0) {
+                    currentBuild.result = 'ABORTED'
+                    error '[INFO] Remote branch is up to date'
+                }
+
+                def commitCode = sh script: "git commit -m '${manifestVar}:${latestRelease}'", returnStatus: true
+                if (commitCode != 0) {
+                    currentBuild.result = 'ABORTED'
+                    error '[ERROR] failed to  commit changes'
+                }
+
+                println '[INFO] New version available'
+                def pushCode = sh script: "git push origin ${nextBranch}", returnStatus: true
+                if (commitCode != 0) {
+                    currentBuild.result = 'ABORTED'
+                    error '[ERRPR] failed to push changes'
+                }
+            }
+        }
+    }
+
+    stage('Archive manifest file') {
+        println '[INFO] Archiving manifest file'
+        archiveArtifacts 'installation/evals/inventories/group_vars/all/manifest.yaml'
+    }
+}

--- a/jobs/release-monitoring/release-monitoring-github/release-monitoring-github.yaml
+++ b/jobs/release-monitoring/release-monitoring-github/release-monitoring-github.yaml
@@ -1,0 +1,52 @@
+---
+- job:
+    name: release-monitoring-github
+    display-name: 'Integreatly Github Release Monitoring'
+    project-type: pipeline
+    concurrent: true
+    parameters:
+      - string:
+          name: 'installationGitUrl'
+          default: 'git@github.com:integr8ly/installation.git'
+          description: '[REQUIRED] The installation repo containing the components meta file (COMPONENTS.yaml)'
+      - string:
+          name: 'installationGitRef'
+          default: 'master'
+          description: '[REQUIRED] The installation git ref'
+      - string:
+          name: 'installationProductBranch'
+          default: '3scale-next'
+          description: '[REQUIRED] The installation git branch to push new version changes'
+      - string:
+          name: 'manifestVar'
+          default: 'threescale_version'
+          description: '[REQUIRED] The manifest variable to be used as the current component version'
+      - string:
+          name: 'projectOrg'
+          default: '3scale'
+          description: '[REQUIRED] github project organization'
+      - string:
+          name: 'projectRepo'
+          default: '3scale-amp-openshift-templates'
+          description: '[REQUIRED] github project repostirory'
+      - string:
+          name: 'githubToken'
+          default: 'jenkins-github-api-token'
+          description: '[REQUIRED] github api token secret text id to be used in its rest api requests'
+      - string:
+          name: 'credentialId'
+          default: 'jenkinsgithub'
+          description: '[REQUIRED] github ssh credential id to be used'
+      - string:
+          name: 'productName'
+          default: '3scale'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+    pipeline-scm:
+      script-path: jobs/release-monitoring/release-monitoring-github/Jenkinsfile
+      scm:
+        - git:
+            branches:
+              - master
+            url: 'https://github.com/integr8ly/ci-cd.git'
+            skip-tag: true
+            wipe-workspace: false

--- a/jobs/release-monitoring/release-monitoring-runner/Jenkinsfile
+++ b/jobs/release-monitoring/release-monitoring-runner/Jenkinsfile
@@ -1,0 +1,48 @@
+#!groovy
+hasChanges = false
+
+def buildParams(newParams) {
+    def jobParams = [
+        string(name: 'installationGitUrl', value: params.installationGitUrl),
+        string(name: 'installationGitRef', value: params.installationGitRef),
+        string(name: 'githubToken', value: params.githubToken),
+        string(name: 'credentialId', value: params.credentialId)
+    ]
+
+    return jobParams + newParams
+}
+
+def runBuild(name, parameters) {
+    def instance = build job: name, parameters: parameters, propagate: false
+    if (instance.result == 'FAILURE') {
+        error('[ERROR] Failed to run release checking job')
+    }
+
+    if (instance.result == 'SUCCESS') {
+        hasChanges = true
+    }   
+
+    return instance
+}
+
+stage('3Scale') {
+    def stageParams = [
+        string(name: 'manifestVar', value: 'threescale_version'),
+        string(name: 'projectOrg', value: '3scale'),
+        string(name: 'projectRepo', value: '3scale-amp-openshift-templates'),
+        string(name: 'productName', value: '3scale'),
+        string(name: 'installationProductBranch', value: '3scale-next')
+    ]
+    def parameters = buildParams(stageParams)
+    runBuild(params.monitoringJob, parameters)
+}
+
+stage('Validation') {
+    if (!hasChanges) {
+        println '[INFO] No updates were found.'
+        currentBuild.result = 'ABORTED'
+        return
+    }
+
+    println '[INFO] New product(s) version(s) available.'
+}

--- a/jobs/release-monitoring/release-monitoring-runner/release-monitoring-runner.yaml
+++ b/jobs/release-monitoring/release-monitoring-runner/release-monitoring-runner.yaml
@@ -1,0 +1,38 @@
+---
+- job:
+    name: release-monitoring-runner
+    display-name: 'Integreatly Release Job Runner'
+    project-type: pipeline
+    concurrent: false
+    triggers:
+      - timed: '@hourly'
+    parameters:
+      - string:
+          name: 'installationGitUrl'
+          default: 'git@github.com:integr8ly/installation.git'
+          description: '[REQUIRED] The installation repo containing the components meta file (COMPONENTS.yaml)'
+      - string:
+          name: 'installationGitRef'
+          default: 'master'
+          description: '[REQUIRED] The installation git ref'
+      - string:
+          name: 'githubToken'
+          default: 'jenkins-github-api-token'
+          description: '[REQUIRED] github api token secret text id to be used in its rest api requests'
+      - string:
+          name: 'credentialId'
+          default: 'jenkinsgithub'
+          description: '[REQUIRED] github ssh credential id to be used'
+      - string:
+          name: 'monitoringJob'
+          default: 'release-monitoring-github'
+          description: '[REQUIRED] Job to be used to search for new product versions'
+    pipeline-scm:
+      script-path: jobs/release-monitoring/release-monitoring-runner/Jenkinsfile
+      scm:
+        - git:
+            branches:
+              - master
+            url: 'https://github.com/integr8ly/ci-cd.git'
+            skip-tag: true
+            wipe-workspace: false

--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -18,7 +18,8 @@ generate_inline_script_job $SCRIPTS_DIR/../jobs/release/release-create/integreat
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release/release-delete/integreatly-release-delete.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/repos/repos-delete-branches-and-tags/repos-delete-branches-and-tags.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/repos/repos-delete-docker-image-tags/repos-delete-docker-image-tags.yaml
-generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/release-monitoring-3scale/release-monitoring-3scale.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/release-monitoring-github/release-monitoring-github.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/release-monitoring-runner/release-monitoring-runner.yaml
 
 #Generated jobs
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/generated/
@@ -26,3 +27,4 @@ jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/generated/
 #Views
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../views/repos/
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../views/release/
+jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../views/monitoring/

--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -18,6 +18,7 @@ generate_inline_script_job $SCRIPTS_DIR/../jobs/release/release-create/integreat
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release/release-delete/integreatly-release-delete.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/repos/repos-delete-branches-and-tags/repos-delete-branches-and-tags.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/repos/repos-delete-docker-image-tags/repos-delete-docker-image-tags.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/release-monitoring-3scale/release-monitoring-3scale.yaml
 
 #Generated jobs
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/generated/

--- a/views/monitoring/monitoring.yml
+++ b/views/monitoring/monitoring.yml
@@ -1,0 +1,11 @@
+- view:
+   name: Integreatly Release Monitoring
+   regex: release-monitoring.*(?<!generated)
+   columns:
+    - status
+    - weather
+    - job
+    - last-success
+    - last-failure
+    - last-duration
+    - build-button

--- a/views/monitoring/monitoring.yml
+++ b/views/monitoring/monitoring.yml
@@ -1,5 +1,5 @@
 - view:
-   name: Integreatly Release Monitoring
+   name: Product Release Monitoring
    regex: release-monitoring.*(?<!generated)
    columns:
     - status


### PR DESCRIPTION
Adds releasing monitoring for 3scale repo.

## Verification steps:

Add the job in jenkins:

```
jenkins-jobs --conf  jenkins_job.ini update jobs/release-monitoring/release-monitoring-3scale/release-monitoring-3scale.yaml
```

Trigger the job (needs a github api token with repo access enabled).

It should create a new "next" repo (3scale-next in this case) with the new identified version or abort the job run in case no new version is available.

I will change the job definition to use the installer upstream repo once the pr is in good shape to be merged.
