### PR TITLE
Smoke tests UNSTABLE on test errors/failures

### DIFF
--- a/jobs/integr8ly/installation-smoke-tests.yaml
+++ b/jobs/integr8ly/installation-smoke-tests.yaml
@@ -30,6 +30,9 @@
           description: 'Provide release version when testing particular release.'
     dsl: |
         node('cirhos_rhel7'){
+
+            Boolean publishTestResults = true
+
             stage('Clone QE repository') {
                 dir('.') {
                     git branch: "${BRANCH}", url: "${REPOSITORY}"
@@ -42,15 +45,27 @@
                     '''
                 }
                 dir('tests/backend-testsuite'){    
-                    sh '''
-                        gulp smoke
-                    '''
+                    String output = sh returnStdout: true, script: 'gulp smoke || true'
+
+                    // To see the output in Jenkins build console log as well
+                    println output
+                    
+                    if(!output.contains('Integreatly Smoke Tests')) {
+                        currentBuild.result = 'FAILURE'
+                        publishTestResults = false
+                    } else if(output.contains('There were test failures')) {
+                        currentBuild.result = 'UNSTABLE'
+                    }
                 }
             }
             stage('Publish test results') {
-                dir('tests/backend-testsuite/reports/') {
-                    archiveArtifacts 'smoke.xml'                  
-                    junit allowEmptyResults:true, testResults: 'smoke.xml'
-                } 
+                if(publishTestResults) {
+                    dir('tests/backend-testsuite/reports/') {
+                        archiveArtifacts 'smoke.xml'                  
+                        junit allowEmptyResults:true, testResults: 'smoke.xml'
+                    }
+                } else {
+                    println 'Publishing the results skipped. Probably due to an error.'
+                }
             }
         }


### PR DESCRIPTION
## What & Why & Motivation
Smoke test job build result should be UNSTABLE in case of test errors/failures. Not failure.

## How
shell script that runs the tests always exits with 0. Outup of the script is parsed to see whether there were test failures or errors. Based on that the build result is set. In case of error the publishing is skipped (no xml report is generated in that case anyway)

## Verification Steps
* `jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/installation-smoke-tests.yaml`
* Run the test suite - you should see 3scale operator failure since this has been removed yesterday. Should be reported, build should be UNSTABLE
* Remove the failing test - should be reported and build should be SUCCESS
* Do some syntax error in gulpfile - should not be reported and build should be FAILURE

Not sure if is is really required to do all this on Jenkins, the change is relatively simple.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO