### PR TITLE
Add pipelines for install/uninstall for the new QE Pony

### DIFF
--- a/jobs/integr8ly/installation-pipeline-qe-pony.yaml
+++ b/jobs/integr8ly/installation-pipeline-qe-pony.yaml
@@ -1,0 +1,104 @@
+---
+
+- job:
+    name: installation-pipeline-qe-pony
+    project-type: pipeline
+    description: "Installs Integreatly remotely from Jenkins slave to QE Pony cluster."
+    sandbox: false
+    concurrent: false
+    parameters:
+        - string:
+            name: REPOSITORY
+            default: https://github.com/integr8ly/installation.git
+            description: "Repository of the Integreatly installer"
+        - string:
+            name: BRANCH
+            default: 'master'
+            description: "Branch of the installer repository"
+        - string:
+            name: CLUSTER_URL
+            description: "URL of cluster for installation."
+        - string:
+            name: GH_CLIENT_ID
+            default: b15294d65592a5e6afb4
+            description: "GitHub Client ID for OAuth Apps, required for some of the walkthroughs. Can be left empty"
+        - string:
+            name: GH_CLIENT_SECRET
+            default: 539a4a94cda8854d610d2dbef25881a31b49cba2
+            description: "GitHub Client Secret for OAuth Apps, required for some of the walkthroughs. Can be left empty"
+        - bool:
+            name: SELF_SIGNED_CERTS
+            default: false
+            description: "Indicates whether cluster uses self signed certificates or not"
+        - string:
+            name: ANSIBLE_USER
+            default: root
+            description: "User for Ansible to access the master node of target cluster"
+        - string:
+            name: MASTER_URLS
+            description: "Comma separated list of URLs for master nodes of target cluster to be used in Ansible inventory file"
+        - string:
+            name: OC_USER
+            description: "OpenShift user for QE cluster."
+        - string:
+            name: OC_PASSWORD
+            description: "OpenShift password for QE cluster."
+    dsl: |
+        timeout(60) { ansiColor('gnome-terminal') { timestamps {
+            node('cirhos_rhel7') {        
+                stage('Verify input') {
+                    if (!MASTER_URLS) {
+                        throw new hudson.AbortException('MASTER_URLS parameter is required!')
+                    }
+                    if (!CLUSTER_URL) {
+                        throw new hudson.AbortException('CLUSTER_URL parameter is required!')
+                    }
+                    if (!OC_USER) {
+                        throw new hudson.AbortException('OC_USER parameter is required!')
+                    }
+                    if (!OC_PASSWORD) {
+                        throw new hudson.AbortException('OC_PASSWORD parameter is required!')
+                    }
+                }
+
+                stage('Clone the installer') {
+                    dir('installation') {
+                        git branch: BRANCH, url: REPOSITORY
+                    } // dir
+                } // stage
+
+                stage('Prepare environment') {
+                    dir('installation') {
+                        sh """
+                            cp ./evals/inventories/hosts.template ./evals/inventories/hosts
+                            sed -i 's/ansible_user=ec2-user/ansible_user=${ANSIBLE_USER}/g' ./evals/inventories/hosts
+                        """
+                    
+                        String masterUrls = MASTER_URLS.replaceAll(~/,[\s]*/, '\\\\n')
+                    
+                        sh """
+                            sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n${masterUrls}@;P;D' ./evals/inventories/hosts
+                        """
+                    
+                        String output = readFile('./evals/inventories/hosts')
+                        println output
+                    } // dir
+                } // stage
+            
+                stage('Execute playbook') {
+                    dir('installation/evals') {
+                    
+                        String githubParams = ''
+                        if(GH_CLIENT_ID && GH_CLIENT_SECRET) {
+                            githubParams = "-e github_client_id=${GH_CLIENT_ID} -e github_client_secret=${GH_CLIENT_SECRET}"
+                        }
+                        githubParams = githubParams + " -e threescale_pvc_rwx_storageclassname=nfs -e che_persistent_volume_storageclassname=nfs"
+                        sh """
+                            sudo oc login ${CLUSTER_URL} -u ${OC_USER} -p ${OC_PASSWORD}
+                            sudo ansible-playbook -i ./inventories/hosts ./playbooks/install.yml ${githubParams} -e eval_self_signed_certs=${SELF_SIGNED_CERTS} 
+                        """
+                    } // dir
+                } // stage
+            } // node
+        }}} // timeout, ansiColor, timestamps
+

--- a/jobs/integr8ly/uninstallation-pipeline-qe-pony.yaml
+++ b/jobs/integr8ly/uninstallation-pipeline-qe-pony.yaml
@@ -1,0 +1,86 @@
+---
+
+- job:
+    name: uninstallation-pipeline-qe-pony
+    project-type: pipeline
+    description: "Uninstalls Integreatly remotely from QE Pony cluster by executing Ansible uninstallation playbook."
+    sandbox: false
+    concurrent: false
+    parameters:
+        - string:
+            name: REPOSITORY
+            default: https://github.com/integr8ly/installation.git
+            description: "Repository of the Integreatly installer"
+        - string:
+            name: BRANCH
+            default: 'master'
+            description: "Branch of the installer repository"
+        - string:
+            name: CLUSTER_URL
+            description: "URL of cluster for uninstallation."
+        - string:
+            name: ANSIBLE_USER
+            default: root
+            description: "User for Ansible to access the master node of target cluster"
+        - string:
+            name: MASTER_URLS
+            description: "Comma separated list of URLs for master nodes of target cluster to be used in Ansible inventory file"
+        - string:
+            name: OC_USER
+            description: "OpenShift user for QE cluster."
+        - string:
+            name: OC_PASSWORD
+            description: "OpenShift password for QE cluster."
+    dsl: |
+        timeout(60) { ansiColor('gnome-terminal') { timestamps {
+            node('cirhos_rhel7') {        
+                stage('Verify input') {
+                    if (!MASTER_URLS) {
+                        throw new hudson.AbortException('MASTER_URLS parameter is required!')
+                    }
+                    if (!CLUSTER_URL) {
+                        throw new hudson.AbortException('CLUSTER_URL parameter is required!')
+                    }
+                    if (!OC_USER) {
+                        throw new hudson.AbortException('OC_USER parameter is required!')
+                    }
+                    if (!OC_PASSWORD) {
+                        throw new hudson.AbortException('OC_PASSWORD parameter is required!')
+                    }
+                }
+
+                stage('Clone the installer') {
+                    dir('installation') {
+                        git branch: BRANCH, url: REPOSITORY
+                    } // dir
+                } // stage
+
+                stage('Prepare environment') {
+                    dir('installation') {
+                        sh """
+                            cp ./evals/inventories/hosts.template ./evals/inventories/hosts
+                            sed -i 's/ansible_user=ec2-user/ansible_user=${ANSIBLE_USER}/g' ./evals/inventories/hosts
+                        """
+                    
+                        String masterUrls = MASTER_URLS.replaceAll(~/,[\s]*/, '\\\\n')
+                    
+                        sh """
+                            sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n${masterUrls}@;P;D' ./evals/inventories/hosts
+                        """
+                    
+                        String output = readFile('./evals/inventories/hosts')
+                        println output
+                    } // dir
+                } // stage
+            
+                stage('Execute playbook') {
+                    dir('installation/evals') {
+                        sh """
+                            sudo oc login ${CLUSTER_URL} -u ${OC_USER} -p ${OC_PASSWORD}
+                            sudo ansible-playbook -i ./inventories/hosts ./playbooks/uninstall.yml
+                        """
+                     } // dir
+                } // stage
+            } // node
+        }}} // timeout, ansiColor, timestamps
+    


### PR DESCRIPTION
## Motivation
QE pony cluster has been reinstalled and it doesn't use a bastion server. This requires a little bit different pipelines for install/uninstall. 
