### PR TITLE
changed pipeline to generate reports despite of test failures

### DIFF
--- a/jobs/integr8ly/after-first-login-tests.yaml
+++ b/jobs/integr8ly/after-first-login-tests.yaml
@@ -31,6 +31,9 @@
           description: 'This optional parameter allows to test particular release version. If not provided, master will be used'
     dsl: |
         node('cirhos_rhel7') {
+            
+            Boolean publishTestResults = true
+            
             stage('Clone QE repository') {
                 dir('.') {
                     git branch: "${BRANCH}", url: "${REPOSITORY}"
@@ -43,15 +46,27 @@
                     '''
                 }
                 dir('tests/backend-testsuite') {
-                    sh '''
-                        gulp after-first-login
-                    '''                
+                    String output = sh returnStdout: true, script: 'gulp after-first-login || true'
+
+                    // To see the output in Jenkins build console log as well
+                    println output
+                    
+                    if(!output.contains('Integreatly After First Login Tests')) {
+                        currentBuild.result = 'FAILURE'
+                        publishTestResults = false
+                    } else if(output.contains('There were test failures')) {
+                        currentBuild.result = 'UNSTABLE'
+                    }              
                 }
             }
             stage('Publish test results') {
-                dir('tests/backend-testsuite/reports/') {
-                    archiveArtifacts 'after-first-login.xml'                  
-                    junit allowEmptyResults:true, testResults: 'after-first-login.xml'
-                } 
+                if (publishTestResults) {
+                    dir('tests/backend-testsuite/reports/') {
+                        archiveArtifacts 'after-first-login.xml'                  
+                        junit allowEmptyResults:true, testResults: 'after-first-login.xml'
+                    } 
+                } else {
+                    println 'Publishing the results skipped. Probably due to an error.'
+                }
             }
         }


### PR DESCRIPTION
## What & Why & Motivation
After-first-login-tests job build result should be UNSTABLE in case of test errors/failures. Not failure.

## How
shell script that runs the tests always exits with 0. Output of the script is parsed to see whether there were test failures or errors. Based on that the build result is set. In case of error the publishing is skipped (no xml report is generated in that case anyway)

## Verification Steps
Go to this pipeline (with the definition the same as the target pipeline): https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/ppaszki-after-first-login/ and check the output of builds 3. and 4. to confirm that the reports are generated with and without failures

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO