### PR TITLE
added archiving screenshots for browser-based tests' errors/ failures

### DIFF
--- a/jobs/integr8ly/browser-based-testsuite-pipeline.yaml
+++ b/jobs/integr8ly/browser-based-testsuite-pipeline.yaml
@@ -50,6 +50,7 @@
                                 sh """
                                 # Disable starting Selenium, Docker is used instead
                                 sed -i 's/"start_process" : true,/"start_process" : false,/g' nightwatch.json
+                                rm -rf ui-testsuite/screenshots ui-testsuite/reports # so that any leftovers from past builds are not archived
                                 npm install
                                 npm test
                                 """   
@@ -67,6 +68,17 @@
                     dir('integreatly-qe/tests/ui-testsuite/reports') {
                         archiveArtifacts '**/*.xml'                  
                         junit allowEmptyResults:true, testResults: '**/*.xml'
+                    }
+                }
+                
+                stage('Publish screenshots for any failures/ errors') {
+                    dir('integreatly-qe/tests/ui-testsuite') {
+                        String testsuiteDirectories = sh returnStdout: true, script: 'ls'
+                        if (testsuiteDirectories.contains('screenshots')) {
+                            archiveArtifacts 'screenshots/**'
+                        } else {
+                            println 'No screenshots found. Skipping this step...'
+                        }
                     }
                 }
             }

--- a/jobs/integr8ly/browser-based-testsuite-pipeline.yaml
+++ b/jobs/integr8ly/browser-based-testsuite-pipeline.yaml
@@ -71,13 +71,12 @@
                     }
                 }
                 
-                stage('Publish screenshots for any failures/ errors') {
+                stage('Save screenshots for any failures/ errors') {
                     dir('integreatly-qe/tests/ui-testsuite') {
-                        String testsuiteDirectories = sh returnStdout: true, script: 'ls'
-                        if (testsuiteDirectories.contains('screenshots')) {
+                        if (fileExists('screenshots')) {
                             archiveArtifacts 'screenshots/**'
                         } else {
-                            println 'No screenshots found. Skipping this step...'
+                            println 'No screenshots found. Skipping...'
                         }
                     }
                 }


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-803

## What
add archiving screenshots for browser-based tests/ failures

## Verification Steps
There is a test pipeline created with the same job definition. Check the output of this build (against master -> no screenshots saved, because there were no errors):

https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/all/job/ppaszki-browser-based/9/console

Check the output of this build (against a branch with tests that will fail and confirm that the screenshots are saved):

https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/all/job/ppaszki-browser-based/8/console

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->
