### PR TITLE
Remove evals/ dir from paths

### DIFF
--- a/jobs/integr8ly/clean-uninstallation-pipeline.yaml
+++ b/jobs/integr8ly/clean-uninstallation-pipeline.yaml
@@ -33,21 +33,21 @@
                     stage('Prepare environment') {
                         dir('installation') {
                             sh """
-                                cp ./evals/inventories/hosts.template ./evals/inventories/hosts
-                                sed -i 's/ansible_user=ec2-user/ansible_user=root/g' ./evals/inventories/hosts
+                                cp ./inventories/hosts.template ./inventories/hosts
+                                sed -i 's/ansible_user=ec2-user/ansible_user=root/g' ./inventories/hosts
                             """
             
                             sh """
-                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\ntrepel-merrn-1@;P;D' ./evals/inventories/hosts
+                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\ntrepel-merrn-1@;P;D' ./inventories/hosts
                             """
                             
-                            String output = readFile('./evals/inventories/hosts')
+                            String output = readFile('./inventories/hosts')
                             println output
                         } // dir
                     } // stage
                 
                     stage('Execute playbook') {
-                        dir('installation/evals') {
+                        dir('installation') {
                             sh """
                                 ansible-playbook -i ./inventories/hosts ./playbooks/uninstall.yml
                             """

--- a/jobs/integr8ly/installation-pipeline-qe-pony.yaml
+++ b/jobs/integr8ly/installation-pipeline-qe-pony.yaml
@@ -70,23 +70,23 @@
                 stage('Prepare environment') {
                     dir('installation') {
                         sh """
-                            cp ./evals/inventories/hosts.template ./evals/inventories/hosts
-                            sed -i 's/ansible_user=ec2-user/ansible_user=${ANSIBLE_USER}/g' ./evals/inventories/hosts
+                            cp ./inventories/hosts.template ./inventories/hosts
+                            sed -i 's/ansible_user=ec2-user/ansible_user=${ANSIBLE_USER}/g' ./inventories/hosts
                         """
                     
                         String masterUrls = MASTER_URLS.replaceAll(~/,[\s]*/, '\\\\n')
                     
                         sh """
-                            sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n${masterUrls}@;P;D' ./evals/inventories/hosts
+                            sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n${masterUrls}@;P;D' ./inventories/hosts
                         """
                     
-                        String output = readFile('./evals/inventories/hosts')
+                        String output = readFile('./inventories/hosts')
                         println output
                     } // dir
                 } // stage
             
                 stage('Execute playbook') {
-                    dir('installation/evals') {
+                    dir('installation') {
                     
                         String githubParams = ''
                         if(GH_CLIENT_ID && GH_CLIENT_SECRET) {

--- a/jobs/integr8ly/installation-pipeline.yaml
+++ b/jobs/integr8ly/installation-pipeline.yaml
@@ -115,23 +115,23 @@
                     stage('Prepare environment') {
                         dir('installation') {
                             sh """
-                                cp ./evals/inventories/hosts.template ./evals/inventories/hosts
-                                sed -i 's/ansible_user=ec2-user/ansible_user=${ANSIBLE_USER}/g' ./evals/inventories/hosts
+                                cp ./inventories/hosts.template ./inventories/hosts
+                                sed -i 's/ansible_user=ec2-user/ansible_user=${ANSIBLE_USER}/g' ./inventories/hosts
                             """
                             
                             String masterUrls = MASTER_URLS.replaceAll(~/,[\s]*/, '\\\\n')
                             
                             sh """
-                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n${masterUrls}@;P;D' ./evals/inventories/hosts
+                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n${masterUrls}@;P;D' ./inventories/hosts
                             """
                             
-                            String output = readFile('./evals/inventories/hosts')
+                            String output = readFile('./inventories/hosts')
                             println output
                         } // dir
                     } // stage
                     
                     stage('Execute playbook') {
-                        dir('installation/evals') {
+                        dir('installation') {
                             
                             String githubParams = ''
                             if(GH_CLIENT_ID && GH_CLIENT_SECRET) {

--- a/jobs/integr8ly/uninstallation-pipeline-qe-pony.yaml
+++ b/jobs/integr8ly/uninstallation-pipeline-qe-pony.yaml
@@ -58,23 +58,23 @@
                 stage('Prepare environment') {
                     dir('installation') {
                         sh """
-                            cp ./evals/inventories/hosts.template ./evals/inventories/hosts
-                            sed -i 's/ansible_user=ec2-user/ansible_user=${ANSIBLE_USER}/g' ./evals/inventories/hosts
+                            cp ./inventories/hosts.template ./inventories/hosts
+                            sed -i 's/ansible_user=ec2-user/ansible_user=${ANSIBLE_USER}/g' ./inventories/hosts
                         """
                     
                         String masterUrls = MASTER_URLS.replaceAll(~/,[\s]*/, '\\\\n')
                     
                         sh """
-                            sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n${masterUrls}@;P;D' ./evals/inventories/hosts
+                            sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n${masterUrls}@;P;D' ./inventories/hosts
                         """
                     
-                        String output = readFile('./evals/inventories/hosts')
+                        String output = readFile('./inventories/hosts')
                         println output
                     } // dir
                 } // stage
             
                 stage('Execute playbook') {
-                    dir('installation/evals') {
+                    dir('installation') {
                         sh """
                             sudo oc login ${CLUSTER_URL} -u ${OC_USER} -p ${OC_PASSWORD}
                             sudo ansible-playbook -i ./inventories/hosts ./playbooks/uninstall.yml

--- a/jobs/integr8ly/uninstallation-pipeline.yaml
+++ b/jobs/integr8ly/uninstallation-pipeline.yaml
@@ -105,23 +105,23 @@
                     stage('Prepare environment') {
                         dir('installation') {
                             sh """
-                                cp ./evals/inventories/hosts.template ./evals/inventories/hosts
-                                sed -i 's/ansible_user=ec2-user/ansible_user=${ANSIBLE_USER}/g' ./evals/inventories/hosts
+                                cp ./inventories/hosts.template ./inventories/hosts
+                                sed -i 's/ansible_user=ec2-user/ansible_user=${ANSIBLE_USER}/g' ./inventories/hosts
                             """
                             
                             String masterUrls = MASTER_URLS.replaceAll(~/,[\s]*/, '\\\\n')
                             
                             sh """
-                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n${masterUrls}@;P;D' ./evals/inventories/hosts
+                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n${masterUrls}@;P;D' ./inventories/hosts
                             """
                             
-                            String output = readFile('./evals/inventories/hosts')
+                            String output = readFile('./inventories/hosts')
                             println output
                         } // dir
                     } // stage
                     
                     stage('Execute playbook') {
-                        dir('installation/evals') {
+                        dir('installation') {
                             sh """
                                 sudo oc login -u system:admin
                                 sudo ansible-playbook -i ./inventories/hosts ./playbooks/uninstall.yml

--- a/jobs/release/release-create/Jenkinsfile
+++ b/jobs/release/release-create/Jenkinsfile
@@ -178,7 +178,7 @@ node('cirhos_rhel7') {
                     if (!variablesFile) {
                         componentRole = componentConfig?.get('ansible')?.get('role')
                         if (componentRole) {
-                            variablesFile = "evals/roles/${componentRole}/defaults/main.yml"
+                            variablesFile = "roles/${componentRole}/defaults/main.yml"
                         }
                     }
 

--- a/scripts/install-integr8ly-no-bastion.groovy
+++ b/scripts/install-integr8ly-no-bastion.groovy
@@ -9,12 +9,10 @@ node("staging") {
         
         stage('Install'){
             sh '''
-                sed -i 's/rhsso_seed_users_count: 50/rhsso_seed_users_count: 2/g' evals/roles/rhsso/defaults/main.yml
-                cat evals/inventories/hosts
+                sed -i 's/rhsso_seed_users_count: 50/rhsso_seed_users_count: 2/g' roles/rhsso/defaults/main.yml
+                cat inventories/hosts
+                
+                sudo ansible-playbook -i inventories/hosts playbooks/install.yml -e github_client_id=${GH_CLIENT_ID} -e github_client_secret=${GH_CLIENT_SECRET}"  
             '''
-            
-            dir('evals'){
-                sh "sudo ansible-playbook -i inventories/hosts playbooks/install.yml -e github_client_id=${GH_CLIENT_ID} -e github_client_secret=${GH_CLIENT_SECRET}"
-            }
         }
 }

--- a/scripts/uninstall-integr8ly-no-bastion.groovy
+++ b/scripts/uninstall-integr8ly-no-bastion.groovy
@@ -8,7 +8,7 @@
         }
         
         stage('Uninstall'){
-            dir('evals'){
+            dir('.'){
               sh 'sudo ansible-playbook -i inventories/hosts playbooks/uninstall.yml'   
             }
         }


### PR DESCRIPTION
## Motivation
`evals/` folder is being removed from the installer: https://github.com/integr8ly/installation/pull/353

## What
This PR updates paths in pipeline scripts.

## Verification Steps
Test syntax with jjb.

## Progress
- [ ] Update jobs in Jenkins once the [installer PR](https://github.com/integr8ly/installation/pull/353) is merged.