### PR TITLE
INTLY-191 add EVALS user name param for after-first-login-tests

### DIFF
--- a/jobs/integr8ly/after-first-login-tests.yaml
+++ b/jobs/integr8ly/after-first-login-tests.yaml
@@ -26,6 +26,10 @@
           default: 'Password1'
           description: 'Password to login to Integreatly cluster.'
       - string:
+          name: EVALS_USERNAME
+          default: 'evals11@example.com'
+          description: 'Evals account email address for checking created namespaces.'    
+      - string:
           name: RELEASE_VERSION
           default: 'master'
           description: 'This optional parameter allows to test particular release version. If not provided, master will be used'


### PR DESCRIPTION
This is follow up for INTLY-191. I expanded the tests in https://gitlab.cee.redhat.com/integreatly-qe/integreatly-qe/commit/781488485d338622bc22da38e8706d2d51916c01 and we need to have a user name for checking created namespaces. Please check @pawelpaszki 