### PR TITLE
INTLY-850 attempt to improve our pipeline's reporting

### DIFF
--- a/jobs/integr8ly/pds-general.yaml
+++ b/jobs/integr8ly/pds-general.yaml
@@ -58,6 +58,7 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
               - uninstall + install + tests
               - none
     dsl: |
+        def err = null
         try {
             timeout(180) { ansiColor('gnome-terminal') { timestamps {
                 node('cirhos_rhel7') {        
@@ -270,11 +271,14 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
 
                 } // node
             }}} // timeout, ansiColor, timestamps
+        } catch (caughtError){
+            currentBuild.result = 'FAILURE'
+            err = caughtError 
         } finally {
-            notifyBuild(currentBuild.result)
+            notifyBuild(currentBuild.result, err)
         }
 
-        def notifyBuild(String buildStatus) {
+        def notifyBuild(String buildStatus, err) {
             
             // In theory, null means success. In practise if there is an error thrown elsewhere than in the triggered jobs (eg. in wokraround scripts)
             // the job fails but success will be stored in buildStatus anyway
@@ -283,6 +287,10 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             String mailRecipients = "${RECIPIENTS}"
             String subject = "${buildStatus}: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'"
             String body = "${subject}\n\n(${env.BUILD_URL})"
+
+            if(err != null){
+                body = "${body}\n\n FAILURE was ${err}"
+            }
 
             mail body: body, subject: subject, to: mailRecipients
         }

--- a/jobs/integr8ly/qe-poc-master-general.yaml
+++ b/jobs/integr8ly/qe-poc-master-general.yaml
@@ -59,6 +59,7 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             name: OC_PASSWORD
             description: "Default OpenShift admin password when Integr8ly is not installed."    
     dsl: |
+        def err = null
         try {
             timeout(180) { ansiColor('gnome-terminal') { timestamps {
                 node('cirhos_rhel7') {        
@@ -185,11 +186,14 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
 
                 } // node
             }}} // timeout, ansiColor, timestamps
+        } catch (caughtError){
+            currentBuild.result = 'FAILURE'
+            err = caughtError 
         } finally {
-            notifyBuild(currentBuild.result)
+            notifyBuild(currentBuild.result, err)
         }
 
-        def notifyBuild(String buildStatus) {
+        def notifyBuild(String buildStatus, err) {
             
             // In theory, null means success. In practise if there is an error thrown elsewhere than in the triggered jobs (eg. in wokraround scripts)
             // the job fails but success will be stored in buildStatus anyway
@@ -198,6 +202,10 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             String mailRecipients = "${RECIPIENTS}"
             String subject = "${buildStatus}: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]'"
             String body = "${subject}\n\n(${env.BUILD_URL})"
+
+            if(err != null) {
+                body = "${body}\n\n FAILURE was ${err}"
+            }
 
             mail body: body, subject: subject, to: mailRecipients
         }


### PR DESCRIPTION
@trepel @pawelpaszki I tried to update our pipelines so that it receives proper buildStatus in case of e.g uninstallation failure. 
TBH I am not 100% how the buildStatus works (especially the propagate param - why the latest message says `propagate:false to ignore` when it wasn't set to false??) but with this it seems to be a little bit better.