### PR TITLE
Added INTLY-1002 workaround

### DIFF
--- a/jobs/integr8ly/pds-general.yaml
+++ b/jobs/integr8ly/pds-general.yaml
@@ -128,7 +128,9 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                     } // stage
 
                     stage('Install #2') {
-                        if(TO_DO.contains('heavy') || TO_DO.count(' install') >= 2) {
+                        // Added false to always skip this step.
+                        // Workaround for https://issues.jboss.org/browse/INTLY-1002
+                        if(false && (TO_DO.contains('heavy') || TO_DO.count(' install') >= 2)) {
                             build job: 'installation-pipeline', parameters: [
                                 string(name: 'REPOSITORY', value: "${INSTALLATION_REPOSITORY}"),
                                 string(name: 'BRANCH', value: "${INSTALLATION_BRANCH}"),


### PR DESCRIPTION
## Motivation && Why
Workaround for https://issues.jboss.org/browse/INTLY-1002. Running install playbook twice in a row leaves cluster in an inconsistent state (e.g. backup of master-config.yml won't be correct). This causes issues if running uninstall.

## What
Always skipping the 2nd install.

## How
Added `false &&` at the beginning of the condition so that it is always evaluated to 'false'

## Verification Steps
 jenkins-jobs --conf jenkins_jobs.ini test ./integr8ly/pds-general.yaml

Jobs with the modification has been triggered:
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/trepel/job/pds-general/77/

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO
