### PR TITLE
configure_jenkins.sh non interactive

### DIFF
--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -8,7 +8,7 @@ set -e
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CONFIG="$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
 
-alias jenkins-jobs="docker run --env PYTHONHTTPSVERIFY=0 --privileged --rm -it -v $SCRIPTS_DIR/..:$SCRIPTS_DIR/.. docker-registry.engineering.redhat.com/mobile/jenkins-job-builder:latest jenkins-jobs"
+alias jenkins-jobs="docker run --env PYTHONHTTPSVERIFY=0 --privileged --rm -v $SCRIPTS_DIR/..:$SCRIPTS_DIR/.. docker-registry.engineering.redhat.com/mobile/jenkins-job-builder:latest jenkins-jobs"
 
 generate_inline_script_job() {
   $SCRIPTS_DIR/generate_inline_script_pipeline_job -j $1 -o $SCRIPTS_DIR/../jobs/generated


### PR DESCRIPTION
@mikenairn I needed to remove this to be able to successfully run the script on Jenkins because originally I was getting `the input device is not a TTY`. Do you think it's OK to remove? 