### PR TITLE
INTLY-852 fix bastionSlave removal

### DIFF
--- a/jobs/integr8ly/installation-pipeline.yaml
+++ b/jobs/integr8ly/installation-pipeline.yaml
@@ -158,5 +158,10 @@
             // Clean up - remove jenkins slave that was created
         
             Node bastionSlave = Jenkins.instance.getNode(bastionLabel);
-            Jenkins.instance.removeNode(bastionSlave);
+            if(bastionSlave != null) {
+                Boolean isIdle = bastionSlave.toComputer().isIdle();
+                if(isIdle) {
+                    Jenkins.instance.removeNode(bastionSlave);
+                }
+            }
         }

--- a/jobs/integr8ly/uninstallation-pipeline.yaml
+++ b/jobs/integr8ly/uninstallation-pipeline.yaml
@@ -142,5 +142,10 @@
             // Clean up - remove jenkins slave that was created
         
             Node bastionSlave = Jenkins.instance.getNode(bastionLabel);
-            Jenkins.instance.removeNode(bastionSlave);
+            if(bastionSlave != null) {
+                Boolean isIdle = bastionSlave.toComputer().isIdle();
+                if(isIdle) {
+                    Jenkins.instance.removeNode(bastionSlave);
+                }
+            }
         }


### PR DESCRIPTION
There is an issue when we try to remove a non-existing bastion slave or a bastion slave which is executing some tasks. 

I experimented with this and it seems to work good. I executed two parallel jobs on my bastion slave. Originally I got a NPE because both of them were removing the slave every time (you can check https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/uninstallation-pipeline/722/console and the second job is  https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/all/job/tremes-testing-pipeline-INTLY-852/). After this fix both jobs worked as expected (not removing the bastion slave in finally block). 

Please check @trepel @pawelpaszki 
