### PR TITLE
Fix release creation for 1.2.x stream

### DIFF
--- a/jobs/release/release-create/Jenkinsfile
+++ b/jobs/release/release-create/Jenkinsfile
@@ -84,7 +84,11 @@ node('cirhos_rhel7') {
                 def componentConfig = componentConfigs[index]
 
                 dir(componentConfig['name']) {
-                    checkoutGitRepo(componentConfig['gitUrl'], releaseBaseBranch, githubCredentialsID)
+                    try {
+                        checkoutGitRepo(componentConfig['gitUrl'], releaseBranchName, githubCredentialsID)
+                    } catch (Exception e) {
+                        checkoutGitRepo(componentConfig['gitUrl'], releaseBaseBranch, githubCredentialsID)
+                    }
                 }
             }
         }


### PR DESCRIPTION
* Try and checkout a release branch name (v1.2) before falling back to master for each component.