### PR TITLE
Fix pds-general pipeline

### DIFF
--- a/jobs/integr8ly/pds-general.yaml
+++ b/jobs/integr8ly/pds-general.yaml
@@ -212,7 +212,8 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                                 string(name: 'BRANCH', value: "${TEST_SUITES_BRANCH}"),
                                 string(name: 'CLUSTER_URL', value: "https://master.${YOURCITY}.openshiftworkshop.com"),
                                 string(name: 'ADMIN_USERNAME', value: 'admin@example.com'),
-                                string(name: 'ADMIN_PASSWORD', value: 'Password1')]).result
+                                string(name: 'ADMIN_PASSWORD', value: 'Password1'),
+                                string(name: 'EVALS_USERNAME', value: 'evals23@example.com')]).result
                             
                             println "Build finished with ${buildStatus}"
                                 


### PR DESCRIPTION
The `after-first-login-tests` pipeline has newly additional param for EVALS_USERNAME and its value must be the same as the one used in `browser-based-testsuite-pipeline` because the user namespace creation is tested. 


