### PR TITLE
added pipeline to execute alert test

### DIFF
--- a/jobs/integr8ly/alerts-test.yaml
+++ b/jobs/integr8ly/alerts-test.yaml
@@ -1,0 +1,70 @@
+---
+
+- job:
+    name: alerts-test
+    description: 'Executes alert test used to check if all of the alerts except DeadMansSwitch are green and if ApicuritoPodCount alerts gets triggered as expected'
+    project-type: pipeline
+    sandbox: true
+    parameters:
+      - string:
+          name: REPOSITORY
+          default: 'https://gitlab.cee.redhat.com/integreatly-qe/integreatly-qe.git'
+          description: 'QE repository containing the smoke tests source code.'
+      - string:
+          name: BRANCH
+          default: 'master'
+          description: 'Branch of the repository'
+      - string:
+          name: CLUSTER_URL
+          description: 'URL of cluster on which the smoke tests will be executed.'
+      - string:
+          name: ADMIN_USERNAME
+          default: 'admin@example.com'
+          description: 'Username to login to Integreatly cluster.'
+      - string:
+          name: ADMIN_PASSWORD
+          default: 'Password1'
+          description: 'Password to login to Integreatly cluster.'
+    dsl: |
+        timeout(60) { ansiColor('gnome-terminal') { timestamps {
+            node('cirhos_rhel7'){
+
+                Boolean publishTestResults = true
+
+                stage('Clone QE repository') {
+                    dir('.') {
+                        git branch: "${BRANCH}", url: "${REPOSITORY}"
+                    }
+                }
+                stage('Run the alert checking tests'){
+                    dir('tests'){
+                        sh '''
+                            npm install
+                        '''
+                    }
+                    dir('tests/backend-testsuite'){    
+                        sh '''
+                            gulp alerts | tee output.txt
+                        '''
+                        String output = readFile("output.txt");
+                        
+                        if(!output.contains('Integreatly alert trigger test')) {
+                            currentBuild.result = 'FAILURE'
+                            publishTestResults = false
+                        } else if(output.contains('There were test failures')) {
+                            currentBuild.result = 'UNSTABLE'
+                        }
+                    }
+                }
+                stage('Publish test results') {
+                    if(publishTestResults) {
+                        dir('tests/backend-testsuite/reports/') {
+                            archiveArtifacts 'alerts.xml'                  
+                            junit allowEmptyResults:true, testResults: 'alerts.xml'
+                        }
+                    } else {
+                        println 'Publishing the results skipped. Probably due to an error.'
+                    }
+                }
+            }
+        }}}

--- a/jobs/integr8ly/alerts-test.yaml
+++ b/jobs/integr8ly/alerts-test.yaml
@@ -9,14 +9,14 @@
       - string:
           name: REPOSITORY
           default: 'https://gitlab.cee.redhat.com/integreatly-qe/integreatly-qe.git'
-          description: 'QE repository containing the smoke tests source code.'
+          description: 'QE repository containing the test source code.'
       - string:
           name: BRANCH
           default: 'master'
           description: 'Branch of the repository'
       - string:
           name: CLUSTER_URL
-          description: 'URL of cluster on which the smoke tests will be executed.'
+          description: 'URL of cluster on which the test will be executed.'
       - string:
           name: ADMIN_USERNAME
           default: 'admin@example.com'


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-1240

## Why
To allow run the alert checking test on Jenkins

## Verification Steps
1. To make sure that the pipeline definition is syntactically correct:

```jenkins-jobs --conf jenkins_jobs.ini update jobs/integr8ly/alerts-test.yaml```

2. Go to https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Integr8ly/job/alerts-test/1/console and confirm that the pipeline has successfully completed

## Checklist:

- [x] Code has been tested locally by PR requester

## Progress

- [x] Finished task
