### PR TITLE
Ensure installation evals directory exists

### DIFF
--- a/jobs/integr8ly/clean-uninstallation-pipeline.yaml
+++ b/jobs/integr8ly/clean-uninstallation-pipeline.yaml
@@ -27,6 +27,9 @@
                                         userRemoteConfigs: [[url: REPOSITORY]], 
                                         branches: [[name: BRANCH]]
                                         ]
+                            if(!fileExists("evals")) {
+                                sh "ln -s . evals"
+                            }
                         } // dir
                     } // stage
 

--- a/jobs/integr8ly/installation-pipeline-qe-pony.yaml
+++ b/jobs/integr8ly/installation-pipeline-qe-pony.yaml
@@ -73,6 +73,9 @@
                             extensions: [],
                             userRemoteConfigs: [[url: REPOSITORY]]
                         ])
+                        if(!fileExists("evals")) {
+                            sh "ln -s . evals"
+                        }
                     } // dir
                 } // stage
 

--- a/jobs/integr8ly/installation-pipeline.yaml
+++ b/jobs/integr8ly/installation-pipeline.yaml
@@ -118,6 +118,9 @@
                                 extensions: [],
                                 userRemoteConfigs: [[url: REPOSITORY]]
                             ])
+                            if(!fileExists("evals")) {
+                                sh "ln -s . evals"
+                            }
                         } // dir
                     } // stage
 

--- a/jobs/integr8ly/uninstallation-pipeline-qe-pony.yaml
+++ b/jobs/integr8ly/uninstallation-pipeline-qe-pony.yaml
@@ -58,6 +58,9 @@
                             extensions: [],
                             userRemoteConfigs: [[url: REPOSITORY]]
                         ])
+                        if(!fileExists("evals")) {
+                            sh "ln -s . evals"
+                        }
                     } // dir
                 } // stage
 
@@ -88,4 +91,3 @@
                 } // stage
             } // node
         }}} // timeout, ansiColor, timestamps
-    

--- a/jobs/integr8ly/uninstallation-pipeline.yaml
+++ b/jobs/integr8ly/uninstallation-pipeline.yaml
@@ -105,6 +105,9 @@
                                 extensions: [],
                                 userRemoteConfigs: [[url: REPOSITORY]]
                             ])
+                            if(!fileExists("evals")) {
+                                sh "ln -s . evals"
+                            }
                         } // dir
                     } // stage
 

--- a/jobs/release-monitoring/discovery/github/Jenkinsfile
+++ b/jobs/release-monitoring/discovery/github/Jenkinsfile
@@ -219,6 +219,12 @@ def installationManifestFile = './evals/inventories/group_vars/all/manifest.yaml
 
 currentBuild.displayName = "${currentBuild.displayName} ${productName}"
 
+def ensureEvalsDir() {
+    if(!fileExists("evals")) {
+        sh "ln -s . evals"
+    }
+}
+
 node {
     cleanWs()
     stage('Fetch Installation Repo') {
@@ -226,6 +232,7 @@ node {
         cleanWs()
         dir('installation') {
             checkoutGitRepo(installationGitUrl, installationGitRef, githubCredentialsID)
+            ensureEvalsDir()
             releaseConfig = readYaml file: installationManifestFile
             componentRelease = releaseConfig[manifestVar]
         }

--- a/jobs/release/release-create/Jenkinsfile
+++ b/jobs/release/release-create/Jenkinsfile
@@ -28,6 +28,13 @@ String getReleaseTag(version, candidate = null) {
         "release-${version}"
     }
 }
+
+def ensureEvalsDir() {
+    if(!fileExists("evals")) {
+        sh "ln -s . evals"
+    }
+}
+
 //
 
 def installationGitUrl = params.installationGitUrl
@@ -57,6 +64,7 @@ node('cirhos_rhel7') {
 
             dir('installation') {
                 checkoutGitRepo(installationGitUrl, installationGitRef, githubCredentialsID)
+                ensureEvalsDir()
 
                 //Check for an existing release tag on the installation repo and bail if it already exists!!
                 def existingTagCommitHash = sh(returnStdout: true, script: "git ls-remote origin refs/tags/${releaseTagName} | cut -f 1").trim()
@@ -65,7 +73,7 @@ node('cirhos_rhel7') {
                     sh('exit 1')
                 }
 
-                def componentFileName ='COMPONENTS.yaml'
+                def componentFileName = 'COMPONENTS.yaml'
                 def exists = fileExists componentFileName
                 if (exists) {
                     releaseConfig = readYaml file: componentFileName

--- a/scripts/install-integr8ly-no-bastion.groovy
+++ b/scripts/install-integr8ly-no-bastion.groovy
@@ -3,7 +3,10 @@ node("staging") {
         deleteDir()
         stage('Checkout SCM'){
           dir('.') {
-                git branch: "${BRANCH}", url: "https://github.com/${OWNER}/installation.git"
+              git branch: "${BRANCH}", url: "https://github.com/${OWNER}/installation.git"
+              if(!fileExists("evals")) {
+                  sh "ln -s . evals"
+              }
           } 
         }
         

--- a/scripts/uninstall-integr8ly-no-bastion.groovy
+++ b/scripts/uninstall-integr8ly-no-bastion.groovy
@@ -3,7 +3,10 @@
         deleteDir()
         stage('Checkout SCM'){
           dir('.') {
-                git branch: "${BRANCH}", url: "https://github.com/${OWNER}/installation.git"
+            git branch: "${BRANCH}", url: "https://github.com/${OWNER}/installation.git"
+            if(!fileExists("evals")) {
+              sh "ln -s . evals"
+            }
           } 
         }
         


### PR DESCRIPTION
* Add symlink to evals directory if one doesn't already exist.

The evals directory is being removed and everything will be in the root directory of the installation repo as expected see https://github.com/integr8ly/installation/pull/429. We however have a number of jobs that look for files in various places under evals/, this PR adds a symlink for evals after cloning the installation repo in appropriate jobs to ensure they continue to work.

When we are happy no jobs are dealing with old 1.2.x releases, we can update all the jobs to just reference the correct paths from the root directory. 

Note: This should be fine as long as jobs ensure the workspace is cleaned between jobs, and no jobs change the installation reference after the initial clone.