### PR TITLE
added pipeline to run customer-admin-permissions

### DIFF
--- a/jobs/integr8ly/customer-admin-permissions-test.yaml
+++ b/jobs/integr8ly/customer-admin-permissions-test.yaml
@@ -40,7 +40,7 @@
                         git branch: "${BRANCH}", url: "${REPOSITORY}"
                     }
                 }
-                stage('Run the alert checking tests'){
+                stage('Run the customer admin permissions test'){
                     dir('tests'){
                         sh '''
                             npm install

--- a/jobs/integr8ly/customer-admin-permissions-test.yaml
+++ b/jobs/integr8ly/customer-admin-permissions-test.yaml
@@ -1,0 +1,74 @@
+---
+
+- job:
+    name: customer-admin-permissions-test
+    description: 'Executes tests checking whether permissions for the customer-admin are appropriately set'
+    project-type: pipeline
+    sandbox: true
+    parameters:
+      - string:
+          name: REPOSITORY
+          default: 'https://gitlab.cee.redhat.com/integreatly-qe/integreatly-qe.git'
+          description: 'QE repository containing the test source code.'
+      - string:
+          name: BRANCH
+          default: 'master'
+          description: 'Branch of the repository'
+      - string:
+          name: CLUSTER_URL
+          description: 'URL of cluster on which the test will be executed.'
+      - string:
+          name: ADMIN_USERNAME
+          default: 'admin@example.com'
+          description: 'Username to login to Integreatly cluster.'
+      - string:
+          name: ADMIN_PASSWORD
+          default: 'Password1'
+          description: 'Password to login to Integreatly cluster.'
+      - string:
+          name: CUSTOMER_ADMIN_USERNAME
+          default: 'customer-admin@example.com'
+          description: 'customer-admin username to login to Integreatly cluster.'
+    dsl: |
+        timeout(60) { ansiColor('gnome-terminal') { timestamps {
+            node('cirhos_rhel7'){
+
+                Boolean publishTestResults = true
+
+                stage('Clone QE repository') {
+                    dir('.') {
+                        git branch: "${BRANCH}", url: "${REPOSITORY}"
+                    }
+                }
+                stage('Run the alert checking tests'){
+                    dir('tests'){
+                        sh '''
+                            npm install
+                        '''
+                    }
+                    dir('tests/backend-testsuite'){    
+                        sh '''
+                            gulp customer-admin-permissions | tee output.txt
+                        '''
+                        String output = readFile("output.txt");
+                        
+                        if(!output.contains('Integreatly customer-admin Permissions Test')) {
+                            currentBuild.result = 'FAILURE'
+                            publishTestResults = false
+                        } else if(output.contains('There were test failures')) {
+                            currentBuild.result = 'UNSTABLE'
+                        }
+                    }
+                }
+                stage('Publish test results') {
+                    if(publishTestResults) {
+                        dir('tests/backend-testsuite/reports/') {
+                            archiveArtifacts 'customer-admin-permissions.xml'                  
+                            junit allowEmptyResults:true, testResults: 'customer-admin-permissions.xml'
+                        }
+                    } else {
+                        println 'Publishing the results skipped. Probably due to an error.'
+                    }
+                }
+            }
+        }}}

--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -47,9 +47,11 @@ jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/release-monitoring/relea
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/generated/
 
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/after-first-login-tests.yaml
+jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/alerts-test.yaml
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/browser-based-test-executor.yaml
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/browser-based-testsuite-pipeline.yaml
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/clean-uninstallation-pipeline.yaml
+jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/customer-admin-permissions-test.yaml
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/installation-pipeline-qe-pony.yaml
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/installation-pipeline.yaml
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/installation-smoke-tests.yaml


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-1266

## Why
To allow to run the customer-admin-permissions test on Jenkins

## Verification Steps
1. To make sure that the pipeline definition is syntactically correct:

```jenkins-jobs --conf jenkins_jobs.ini update jobs/integr8ly/customer-admin-permissions-test.yaml```

2. Go to https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/all/job/customer-admin-permissions-test/1/console and confirm that the pipeline has successfully completed

## Checklist:

- [x] Code has been tested locally by PR requester

## Progress

- [x] Finished task