### PR TITLE
update rhsso job with new parameters for updating product version

### DIFF
--- a/jobs/release-monitoring/discovery/github/Jenkinsfile
+++ b/jobs/release-monitoring/discovery/github/Jenkinsfile
@@ -257,8 +257,6 @@ node {
     }
 
     stage('Fetch Component Product Version') {
-        def productVersion = ""
-
         // Only set the product version as the latest release if the release tag var is not available
         if (!releaseTagVar) {
           productVersion = latestRelease
@@ -289,7 +287,7 @@ node {
 
           productVersion = productVersion.trim()
 
-          if (productVersion == "") {
+          if (!productVersion) {
             error "[ERROR] Product version for ${productName} was not found. Product Version: ${productVersion}"
           }
         }

--- a/jobs/release-monitoring/discovery/rhsso.yaml
+++ b/jobs/release-monitoring/discovery/rhsso.yaml
@@ -8,9 +8,14 @@
       - timed: '@hourly'
     parameters:
       - string:
-          name: 'manifestVar'
+          name: 'releaseTagVar'
           default: 'rhsso_operator_release_tag'
-          description: '[REQUIRED] The manifest variable to be used as the current component version'
+          description: '[OPTIONAL] The manifest variable to be used as the current component release tag'
+          read-only: true
+      - string:
+          name: 'productVersionVar'
+          default: 'rhsso_version'
+          description: '[REQUIRED] The manifest variable to be used as the current component product version'
           read-only: true
       - string:
           name: 'projectOrg'
@@ -26,6 +31,16 @@
           name: 'productName'
           default: 'rhsso'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          read-only: true
+      - string:
+          name: 'productVersionLocation'
+          default: 'pkg/keycloak/keycloak.go'
+          description: '[OPTIONAL] Path to the file where the product version of the component is declared'
+          read-only: true
+      - string:
+          name: 'productVersionIdentifier'
+          default: 'SSO_VERSION'
+          description: '[OPTIONAL] Identifier to be used to retrieve the product version from the productVersionLocation'
           read-only: true
     pipeline-scm:
       script-path: jobs/release-monitoring/discovery/github/Jenkinsfile


### PR DESCRIPTION
## Motivation
Automate update of the product version for RHSSO, `rhsso_version`, when a new release is found.

## What
- Added following parameters to the RHSSO job for updating the product version
  - release tag variable, product version variable, product version location, product version identifier

The RHSSO version should now be retrieved from the [keycloak operator](https://github.com/integr8ly/keycloak-operator/blob/master/pkg/keycloak/keycloak.go#L30)
