### PR TITLE
update middleware monitoring job with new product version param

### DIFF
--- a/jobs/release-monitoring/discovery/middleware-monitoring.yaml
+++ b/jobs/release-monitoring/discovery/middleware-monitoring.yaml
@@ -8,9 +8,9 @@
       - timed: '@hourly'
     parameters:
       - string:
-          name: 'manifestVar'
+          name: 'releaseTagVar'
           default: 'middleware_monitoring_operator_release_tag'
-          description: '[REQUIRED] The manifest variable to be used as the current component version'
+          description: '[OPTIONAL] The manifest variable to be used as the current component release tag'
           read-only: true
       - string:
           name: 'projectOrg'
@@ -20,12 +20,12 @@
       - string:
           name: 'projectRepo'
           default: 'application-monitoring-operator'
-          description: '[REQUIRED] github project repostirory'
+          description: '[REQUIRED] github project repository'
           read-only: true
       - string:
           name: 'productName'
           default: 'middleware-monitoring'
-          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
     pipeline-scm:
       script-path: jobs/release-monitoring/discovery/github/Jenkinsfile

--- a/jobs/release-monitoring/discovery/rhsso.yaml
+++ b/jobs/release-monitoring/discovery/rhsso.yaml
@@ -25,12 +25,12 @@
       - string:
           name: 'projectRepo'
           default: 'keycloak-operator'
-          description: '[REQUIRED] github project repostirory'
+          description: '[REQUIRED] github project repository'
           read-only: true
       - string:
           name: 'productName'
           default: 'rhsso'
-          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
       - string:
           name: 'productVersionLocation'

--- a/jobs/release-monitoring/discovery/webapp.yaml
+++ b/jobs/release-monitoring/discovery/webapp.yaml
@@ -25,7 +25,7 @@
       - string:
           name: 'projectRepo'
           default: 'tutorial-web-app-operator'
-          description: '[REQUIRED] github project repostirory'
+          description: '[REQUIRED] github project repository'
           read-only: true
       - string:
           name: 'productName'


### PR DESCRIPTION
## Motivation
Update middleware monitoring job to use new parameter for its product version

## What
- Use `productVersionVar` instead of `manifestVar`