### PR TITLE
update gitea job to use new params for updating product version

### DIFF
--- a/jobs/release-monitoring/discovery/gitea.yaml
+++ b/jobs/release-monitoring/discovery/gitea.yaml
@@ -8,9 +8,14 @@
       - timed: '@hourly'
     parameters:
       - string:
-          name: 'manifestVar'
+          name: 'releaseTagVar'
           default: 'gitea_operator_release_tag'
-          description: '[REQUIRED] The manifest variable to be used as the current component version'
+          description: '[OPTIONAL] The manifest variable to be used as the current component release tag'
+          read-only: true
+      - string:
+          name: 'productVersionVar'
+          default: 'gitea_version'
+          description: '[REQUIRED] The manifest variable to be used as the current component product version'
           read-only: true
       - string:
           name: 'projectOrg'
@@ -20,12 +25,22 @@
       - string:
           name: 'projectRepo'
           default: 'gitea-operator'
-          description: '[REQUIRED] github project repostirory'
+          description: '[REQUIRED] github project repository'
           read-only: true
       - string:
           name: 'productName'
           default: 'gitea'
-          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
+          read-only: true
+      - string:
+          name: 'productVersionLocation'
+          default: 'pkg/controller/gitea/templateHelper.go'
+          description: '[OPTIONAL] Path to the file where the product version of the component is declared'
+          read-only: true
+      - string:
+          name: 'productVersionIdentifier'
+          default: 'GiteaVersion'
+          description: '[OPTIONAL] Identifier to be used to retrieve the product version from the productVersionLocation'
           read-only: true
     pipeline-scm:
       script-path: jobs/release-monitoring/discovery/github/Jenkinsfile

--- a/jobs/release-monitoring/discovery/github/Jenkinsfile
+++ b/jobs/release-monitoring/discovery/github/Jenkinsfile
@@ -204,6 +204,22 @@ def when(boolean condition, body) {
     }
 }
 
+def ensureEvalsDir() {
+    if (!fileExists("evals")) {
+        sh "ln -s . evals"
+    }
+}
+
+def updateManifestVariable(manifestFileTxt, name, value) {
+    if (name && value) {
+        println("Updating manifest variable: name = ${name}, value = ${value}")
+        manifestFileTxt = manifestFileTxt.replaceFirst(/${name}: '.*'/, "${name}: '${value}'")
+    } else {
+        println("Unable to update manifest variable: name = ${name}, value = ${value}")
+    }
+    return manifestFileTxt
+}
+
 //Helper methods
 
 def installationGitUrl = params.installationGitUrl ?: 'git@github.com:integr8ly/installation.git'
@@ -222,20 +238,6 @@ def nextBranch = params.installationProductBranch ?: "${productName}-next"
 def installationManifestFile = './evals/inventories/group_vars/all/manifest.yaml'
 
 currentBuild.displayName = "${currentBuild.displayName} ${productName}"
-
-def ensureEvalsDir() {
-    if (!fileExists("evals")) {
-        sh "ln -s . evals"
-    }
-}
-
-def updateManifestVariable(manifestFileTxt, name, value) {
-    if (name && value) {
-        manifestFileTxt.replaceFirst(/${name}: '.*'/, "${name}: '${value}'")
-    } else {
-        println("Unable to update manifest variable: name = ${name}, value = ${value}")
-    }
-}
 
 node {
     cleanWs()
@@ -319,8 +321,8 @@ node {
                 when(isGARelease) {
                     gitCommitWhenChanges("Updated ${productName} product version to ${latestRelease}") { msgs ->
                         manifestFileTxt = readFile(installationManifestFile)
-                        updateManifestVariable(manifestFileTxt, releaseTagVar, latestRelease)
-                        updateManifestVariable(manifestFileTxt, productVersionVar, productVersion)
+                        manifestFileTxt = updateManifestVariable(manifestFileTxt, releaseTagVar, latestRelease)
+                        manifestFileTxt = updateManifestVariable(manifestFileTxt, productVersionVar, productVersion)
                         writeFile file: installationManifestFile, text: manifestFileTxt
                     }
                 }


### PR DESCRIPTION
## Motivation
Automate update of the product version for Gitea, `gitea_version`, when a new release is found.

## What
Added following parameters to the Gitea job for updating the product version
- release tag variable, product version variable, product version location, product version identifier

The Gitea version should now be retrieved from the [gitea operator](https://github.com/integr8ly/gitea-operator/blob/master/pkg/controller/gitea/templateHelper.go#L18)