### PR TITLE
Updated host for clean uninstall

### DIFF
--- a/jobs/integr8ly/clean-uninstallation-pipeline.yaml
+++ b/jobs/integr8ly/clean-uninstallation-pipeline.yaml
@@ -14,6 +14,10 @@
           name: BRANCH
           default: 'master'
           description: 'Branch of the installer repository'
+      - string:
+          name: RECIPIENTS
+          default: integreatly-qe@redhat.com
+          description: 'Whitespace- or comma-separated list of recipient addresses'
     triggers:
       - timed: 'H H(0-5) * * *'
     dsl: |
@@ -41,7 +45,7 @@
                             """
             
                             sh """
-                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\ntrepel-merrn-1@;P;D' ./evals/inventories/hosts
+                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n10.8.249.123@;P;D' ./evals/inventories/hosts
                             """
                             
                             String output = readFile('./evals/inventories/hosts')
@@ -60,7 +64,7 @@
                     currentBuild.result = 'FAILURE'
                     throw any
                 } finally {
-                    step([$class: 'Mailer', notifyEveryUnstableBuild: true, recipients: 'trepel@redhat.com', sendToIndividuals: true])
+                    step([$class: 'Mailer', notifyEveryUnstableBuild: true, recipients: "${RECIPIENTS}", sendToIndividuals: true])
                 } // finally
             } // node
 


### PR DESCRIPTION
## Motivation & Why
New cluster has been created for this. I also parametrized the recipients so we can add personal addresses, eg. when there your turn in rotation.

## What & How
Parametrized recipients and used hard-coded value for master node.

## Verification Steps
jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/clean-uninstallation-pipeline.yaml

See also 145-151 builds here:
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Nightly/job/clean-uninstallation-pipeline/

If you really want, you can add `throw new Exception('Test error')` to simulate an error and observe whether the email notification really works.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO
