### PR TITLE
update fuse job to use new params for updating fuse product version

### DIFF
--- a/jobs/release-monitoring/discovery/fuse.yaml
+++ b/jobs/release-monitoring/discovery/fuse.yaml
@@ -8,9 +8,14 @@
       - timed: '@hourly'
     parameters:
       - string:
-          name: 'manifestVar'
+          name: 'releaseTagVar'
           default: 'fuse_release_tag'
-          description: '[REQUIRED] The manifest variable to be used as the current component version'
+          description: '[OPTIONAL] The manifest variable to be used as the current component release tag'
+          read-only: true
+      - string:
+          name: 'productVersionVar'
+          default: 'fuse_version'
+          description: '[REQUIRED] The manifest variable to be used as the current component product version'
           read-only: true
       - string:
           name: 'projectOrg'
@@ -31,6 +36,16 @@
           name: 'releaseFetchMethod'
           default: 'tag'
           description: '[REQUIRED] Method to fetch latest release which can either be by tag or by release'
+          read-only: true
+      - string:
+          name: 'productVersionLocation'
+          default: 'fis-console-cluster-template.json'
+          description: '[OPTIONAL] Path to the file where the product version of the component is declared'
+          read-only: true
+      - string:
+          name: 'productVersionIdentifier'
+          default: 'openshift.io/display-name'
+          description: '[OPTIONAL] Identifier to be used to retrieve the product version from the productVersionLocation'
           read-only: true
     pipeline-scm:
       script-path: jobs/release-monitoring/discovery/github/Jenkinsfile

--- a/jobs/release-monitoring/discovery/github/Jenkinsfile
+++ b/jobs/release-monitoring/discovery/github/Jenkinsfile
@@ -289,6 +289,11 @@ node {
                 productVersion = productVersion.replaceAll("v", "")
             }
 
+            if (productName == "fuse") {
+              productVersion = sh(returnStdout: true, script: "curl -i '${templateUrl}' | grep '${productVersionIdentifier}' | awk -F ':' '{print \$2}'")
+              productVersion = productVersion.replaceAll("[^0-9.]", "")
+            }
+
             productVersion = productVersion.trim()
 
             if (!productVersion) {


### PR DESCRIPTION
## Motivation
Automate update of the product version for Fuse, `fuse_version`, when a new release is found.

## What
Added following parameters to the Fuse job for updating the product version
- release tag variable, product version variable, product version location, product version identifier

Updated Jenkinsfile to retrieve the fuse version from the [fuse console cluster template](https://github.com/jboss-fuse/application-templates/blob/application-templates-2.1.fuse-710016-redhat-00002/fis-console-cluster-template.json#L6)

**NOTE**: This is just a temporary solution until the Fuse team creates a metadata which maps the product version to the branches/tags of their productized repos.