### PR TITLE
Using oc credentials from parameters

### DIFF
--- a/jobs/integr8ly/qe-poc-master-general.yaml
+++ b/jobs/integr8ly/qe-poc-master-general.yaml
@@ -85,8 +85,8 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                             string(name: 'CLUSTER_URL', value: "${CLUSTER_URL}"),
                             string(name: 'ANSIBLE_USER', value: "${ANSIBLE_USER}"),
                             string(name: 'MASTER_URLS', value: "${MASTER_URLS}"),
-                            string(name: 'OC_USER', value: 'admin@example.com'),
-                            string(name: 'OC_PASSWORD', value: 'Password1')]
+                            string(name: 'OC_USER', value: "${OC_USER}"),
+                            string(name: 'OC_PASSWORD', value: "${OC_PASSWORD}")]
                                 
                         // Waiting for 5 minutes so that resources scheduled for termination are actually terminated
                         sleep time: 5, unit: 'MINUTES'


### PR DESCRIPTION
## Motivation & Why
The 'trepel' user should always be present on QE PoC cluster. The install playbook does not remove it, it just hides the IDP, but the user can still be used for oc login command. This is safer since this job will work even if the integreatly is not installed on the cluster - in such case there is no 'admin@example.com' user and this job would fail.

## What & How

Used the values from parameters instead of hard-coded values.

## Verification Steps
jenkins-jobs --conf jenkins_jobs.ini test integr8ly/qe-poc-master-general.yaml

I haven't tried just yet, but that is relatively simple change.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO
