### PR TITLE
Update fuse online service discovery job with new param

### DIFF
--- a/jobs/release-monitoring/discovery/fuse-online.yaml
+++ b/jobs/release-monitoring/discovery/fuse-online.yaml
@@ -8,9 +8,9 @@
       - timed: '@hourly'
     parameters:
       - string:
-          name: 'manifestVar'
+          name: 'releaseTagVar'
           default: 'fuse_online_release_tag'
-          description: '[REQUIRED] The manifest variable to be used as the current component version'
+          description: '[OPTIONAL] The manifest variable to be used as the current component release tag'
           read-only: true
       - string:
           name: 'projectOrg'


### PR DESCRIPTION
## What
Use new parameter `releaseTagVar` instead of `manifestVar` for specifying the release tag to keep consistent with the vars used in other jobs.