### PR TITLE
add service discovery job for backup container

### DIFF
--- a/jobs/release-monitoring/branch/backup-container-next.yaml
+++ b/jobs/release-monitoring/branch/backup-container-next.yaml
@@ -1,0 +1,28 @@
+---
+- job:
+    name: release-monitoring-branch/backup-container-next
+    display-name: 'Backup Container'
+    project-type: pipeline
+    concurrent: false
+    parameters:
+      - string:
+          name: 'installationGitUrl'
+          default: 'git@github.com:integr8ly/installation.git'
+          description: '[REQUIRED] The installation repo containing the components meta file (COMPONENTS.yaml)'
+      - string:
+          name: 'installationProductBranch'
+          default: 'backup-container-next'
+          description: '[REQUIRED] The installation git branch to push new version changes'
+      - string:
+          name: 'productName'
+          default: 'backup-container'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+    pipeline-scm:
+      script-path: jobs/release-monitoring/branch/Jenkinsfile
+      scm:
+        - git:
+            branches:
+              - master
+            url: 'https://github.com/integr8ly/ci-cd.git'
+            skip-tag: true
+            wipe-workspace: false

--- a/jobs/release-monitoring/discovery/backup-container.yaml
+++ b/jobs/release-monitoring/discovery/backup-container.yaml
@@ -1,0 +1,38 @@
+---
+- job:
+    name: release-monitoring-discovery/backup-container
+    display-name: 'Backup Container'
+    project-type: pipeline
+    concurrent: false
+    triggers:
+      - timed: '@hourly'
+    parameters:
+      - string:
+          name: 'productVersionVar'
+          default: 'backup_version'
+          description: '[REQUIRED] The manifest variable to be used as the current component version'
+          read-only: true
+      - string:
+          name: 'projectOrg'
+          default: 'integr8ly'
+          description: '[REQUIRED] github project organization'
+          read-only: true
+      - string:
+          name: 'projectRepo'
+          default: 'backup-container-image'
+          description: '[REQUIRED] github project repostirory'
+          read-only: true
+      - string:
+          name: 'productName'
+          default: 'backup-container'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          read-only: true
+    pipeline-scm:
+      script-path: jobs/release-monitoring/discovery/github/Jenkinsfile
+      scm:
+        - git:
+            branches:
+              - master
+            url: 'https://github.com/integr8ly/ci-cd.git'
+            skip-tag: true
+            wipe-workspace: false

--- a/jobs/release-monitoring/discovery/github/Jenkinsfile
+++ b/jobs/release-monitoring/discovery/github/Jenkinsfile
@@ -213,7 +213,7 @@ def ensureEvalsDir() {
 def updateManifestVariable(manifestFileTxt, name, value) {
     if (name && value) {
         println("Updating manifest variable: name = ${name}, value = ${value}")
-        manifestFileTxt = manifestFileTxt.replaceFirst(/${name}: '.*'/, "${name}: '${value}'")
+        manifestFileTxt = manifestFileTxt.replaceFirst(/${name}: .*/, "${name}: '${value}'")
     } else {
         println("Unable to update manifest variable: name = ${name}, value = ${value}")
     }

--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -21,6 +21,7 @@ generate_inline_script_job $SCRIPTS_DIR/../jobs/release/release-delete/integreat
 generate_inline_script_job $SCRIPTS_DIR/../jobs/repos/repos-delete-branches-and-tags/repos-delete-branches-and-tags.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/repos/repos-delete-docker-image-tags/repos-delete-docker-image-tags.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/discovery/3scale.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/discovery/backup-container.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/discovery/fuse.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/discovery/fuse-online.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/discovery/gitea.yaml
@@ -30,6 +31,7 @@ generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/discovery/rhs
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/discovery/webapp.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/discovery/amq-online.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/branch/3scale-next.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/branch/backup-container-next.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/branch/fuse-next.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/branch/fuse-online-next.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/branch/gitea-next.yaml


### PR DESCRIPTION
## Motivation
Automate discovery for the [backup container image](https://github.com/integr8ly/backup-container-image/releases) releases.

## What
- Add discovery job for the backup container image releases
- Add branch job for the backup container image release to create the `backup-container-next` branch in the installation repo.

Test Release PR
- ~~https://github.com/integr8ly/installation/pull/456/files~~
- https://github.com/integr8ly/installation/pull/460