### PR TITLE
Removed workaround for INTLY-1002

### DIFF
--- a/jobs/integr8ly/pds-general.yaml
+++ b/jobs/integr8ly/pds-general.yaml
@@ -128,9 +128,7 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                     } // stage
 
                     stage('Install #2') {
-                        // Added false to always skip this step.
-                        // Workaround for https://issues.jboss.org/browse/INTLY-1002
-                        if(false && (TO_DO.contains('heavy') || TO_DO.count(' install') >= 2)) {
+                        if(TO_DO.contains('heavy') || TO_DO.count(' install') >= 2) {
                             build job: 'installation-pipeline', parameters: [
                                 string(name: 'REPOSITORY', value: "${INSTALLATION_REPOSITORY}"),
                                 string(name: 'BRANCH', value: "${INSTALLATION_BRANCH}"),


### PR DESCRIPTION
## Motivation & Why
https://issues.jboss.org/browse/INTLY-1002 has been resolved. Workaround should no longer be required.

## What & How
Removed the workaround so that 2nd install in not skipped.

## Verification Steps
jenkins-jobs --conf jenkins_jobs.ini test integr8ly/pds-general.yaml

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO