### PR TITLE
Patching the web-app to master in PDS install

### DIFF
--- a/jobs/integr8ly/installation-pipeline.yaml
+++ b/jobs/integr8ly/installation-pipeline.yaml
@@ -175,6 +175,9 @@
                             // this patches WALKTHROUGHS_LOCATIONS to use master tag
                             sh """
                                 sudo oc patch webapp/tutorial-web-app-operator -n webapp --type merge -p '{ "spec": { "template": { "parameters": { "WALKTHROUGHS_LOCATION": "https://github.com/integr8ly/tutorial-web-app-walkthroughs#master" } } } }' || true
+
+                                # patch of tutorial-web-app, workaround for https://issues.jboss.org/browse/INTLY-1201
+                                sudo oc patch deploymentconfig/tutorial-web-app -n webapp -p '{ "spec": { "template": { "spec": { "containers": [{ "name": "tutorial-web-app", "image": "quay.io/integreatly/tutorial-web-app:master" }]}}}}' || true
                             """
                         }
                     } // stage


### PR DESCRIPTION
## Motivation & Why
<!-- Add references to relevant tickets or a short description of what motivated you to do it. -->

This patching has been removed by this commit:
https://github.com/integr8ly/ci-cd/commit/e1acafaff04a21dd214444196627565a765f4310#diff-fd96ecbcc8a29bcd02a92f6adfaac2a2L267

Adding it back

## What & How
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Adding the oc patch command to that changes the tutorial-web-app version to 'master'. This is to partially workaround https://issues.jboss.org/browse/INTLY-1201

## Verification Steps
jenkins-jobs --conf jenkins_jobs.ini test integr8ly/installation-pipeline.yaml


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO


