### PR TITLE
Simplify uninstall pipeline as well

### DIFF
--- a/jobs/integr8ly/pds-general.yaml
+++ b/jobs/integr8ly/pds-general.yaml
@@ -74,9 +74,8 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                                 string(name: 'REPOSITORY', value: "${INSTALLATION_REPOSITORY}"),
                                 string(name: 'BRANCH', value: "${INSTALLATION_BRANCH}"),
                                 string(name: 'ANSIBLE_USER', value: 'ec2-user'),
-                                string(name: 'MASTER_URLS', value: "master1.${YOURCITY}.internal"),
+                                string(name: 'YOURCITY', value: "${YOURCITY}"),
                                 string(name: 'BASTION_USER', value: 'ec2-user'),
-                                string(name: 'BASTION_URL', value: "bastion.${YOURCITY}.openshiftworkshop.com"),
                                 string(name: 'BASTION_PRIVATE_KEY_ID', value: 'pds-bastion-pem')]
                                 
                             // Waiting for 5 minutes so that resources scheduled for termination are actually terminated
@@ -92,9 +91,8 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                                 string(name: 'REPOSITORY', value: "${INSTALLATION_REPOSITORY}"),
                                 string(name: 'BRANCH', value: "${INSTALLATION_BRANCH}"),
                                 string(name: 'ANSIBLE_USER', value: 'ec2-user'),
-                                string(name: 'MASTER_URLS', value: "master1.${YOURCITY}.internal"),
+                                string(name: 'YOURCITY', value: "${YOURCITY}"),
                                 string(name: 'BASTION_USER', value: 'ec2-user'),
-                                string(name: 'BASTION_URL', value: "bastion.${YOURCITY}.openshiftworkshop.com"),
                                 string(name: 'BASTION_PRIVATE_KEY_ID', value: 'pds-bastion-pem')]
                                 
                             // Waiting for 1 minute so that resources scheduled for termination are actually terminated
@@ -215,9 +213,8 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                                 string(name: 'REPOSITORY', value: "${INSTALLATION_REPOSITORY}"),
                                 string(name: 'BRANCH', value: "${INSTALLATION_BRANCH}"),
                                 string(name: 'ANSIBLE_USER', value: 'ec2-user'),
-                                string(name: 'MASTER_URLS', value: "master1.${YOURCITY}.internal"),
+                                string(name: 'YOURCITY', value: "${YOURCITY}"),
                                 string(name: 'BASTION_USER', value: 'ec2-user'),
-                                string(name: 'BASTION_URL', value: "bastion.${YOURCITY}.openshiftworkshop.com"),
                                 string(name: 'BASTION_PRIVATE_KEY_ID', value: 'pds-bastion-pem')]
 
                             sleep time: 3, unit: 'MINUTES'

--- a/jobs/integr8ly/uninstallation-pipeline.yaml
+++ b/jobs/integr8ly/uninstallation-pipeline.yaml
@@ -16,19 +16,16 @@
             default: 'master'
             description: "Branch of the installer repository"
         - string:
+            name: YOURCITY
+            description: "City or Customer (5 char min.) plus the generated hash, e.g. qebrno-5d10 [required]"    
+        - string:
             name: ANSIBLE_USER
             default: ec2-user
             description: "User for Ansible to access the master node of target cluster"
         - string:
-            name: MASTER_URLS
-            description: "Comma separated list of URLs for master nodes of target cluster to be used in Ansible inventory file"
-        - string:
             name: BASTION_USER
             default: ec2-user
             description: "User capable of SSH-ing to bastion server"
-        - string:
-            name: BASTION_URL
-            description: "URL for bastion server the target cluster is hidden behind"
         - string:
             name: BASTION_PRIVATE_KEY_ID
             description: "ID of SSH Credentials (private key) used for SSH-ing to bastion"
@@ -40,18 +37,16 @@
 
         import hudson.plugins.sshslaves.verifiers.*
 
+        String MASTER_URL = "master1.${YOURCITY}.internal"
+        String BASTION_URL = "bastion.${YOURCITY}.openshiftworkshop.com"    
         String bastionLabel = "${BASTION_URL}-slave"
 
         try {
             timeout(60) { ansiColor('gnome-terminal') { timestamps {
                 node('cirhos_rhel7') {        
                     stage('Verify input') {
-                        if (!MASTER_URLS) {
-                            throw new hudson.AbortException('MASTER_URLS parameter is required!')
-                        }
-                        
-                        if (!BASTION_URL) {
-                            throw new hudson.AbortException('BASTION_URL parameter is required!')
+                        if (!YOURCITY) {
+                            throw new hudson.AbortException('YOURCITY parameter is required!')
                         }
                     }
 


### PR DESCRIPTION
We don't need to provide MASTER_URLS and BASTION_URL for RHPDS cluster because the format of these values is always the same.