### PR TITLE
Add service discovery for codeready

### DIFF
--- a/jobs/release-monitoring/branch/codeready-next.yaml
+++ b/jobs/release-monitoring/branch/codeready-next.yaml
@@ -1,0 +1,28 @@
+---
+- job:
+    name: release-monitoring-branch/codeready-next
+    display-name: 'CodeReady'
+    project-type: pipeline
+    concurrent: false
+    parameters:
+      - string:
+          name: 'installationGitUrl'
+          default: 'git@github.com:integr8ly/installation.git'
+          description: '[REQUIRED] The installation repo containing the components meta file (COMPONENTS.yaml)'
+      - string:
+          name: 'installationProductBranch'
+          default: 'codeready-next'
+          description: '[REQUIRED] The installation git branch to push new version changes'
+      - string:
+          name: 'productName'
+          default: 'codeready'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
+    pipeline-scm:
+      script-path: jobs/release-monitoring/branch/Jenkinsfile
+      scm:
+        - git:
+            branches:
+              - master
+            url: 'https://github.com/integr8ly/ci-cd.git'
+            skip-tag: true
+            wipe-workspace: false

--- a/jobs/release-monitoring/discovery/codeready.yaml
+++ b/jobs/release-monitoring/discovery/codeready.yaml
@@ -1,31 +1,31 @@
 ---
 - job:
-    name: release-monitoring-discovery/fuse
-    display-name: 'Fuse'
+    name: release-monitoring-discovery/codeready
+    display-name: 'CodeReady'
     project-type: pipeline
     concurrent: false
     triggers:
       - timed: '@hourly'
     parameters:
       - string:
-          name: 'manifestVar'
-          default: 'fuse_release_tag'
+          name: 'productVersionVar'
+          default: 'che_version'
           description: '[REQUIRED] The manifest variable to be used as the current component version'
           read-only: true
       - string:
           name: 'projectOrg'
-          default: 'jboss-fuse'
+          default: 'redhat-developer'
           description: '[REQUIRED] github project organization'
           read-only: true
       - string:
           name: 'projectRepo'
-          default: 'application-templates'
-          description: '[REQUIRED] github project repostirory'
+          default: 'codeready-workspaces-deprecated'
+          description: '[REQUIRED] github project repository'
           read-only: true
       - string:
           name: 'productName'
-          default: 'fuse'
-          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          default: 'codeready'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
       - string:
           name: 'releaseFetchMethod'
@@ -34,7 +34,7 @@
           read-only: true
       - string:
           name: 'gaReleaseTagRef'
-          default: 'redhat'
+          default: 'GA'
           description: '[REQUIRED] Reference used to filter GA releases from the repository tags'
           read-only: true
     pipeline-scm:

--- a/jobs/release-monitoring/discovery/github/Jenkinsfile
+++ b/jobs/release-monitoring/discovery/github/Jenkinsfile
@@ -71,20 +71,17 @@ def gitFetch(url, gitTokenId) {
 }
 
 //Gets the latest release by git tags
-def getLatestReleaseByTag(gitOrg, gitRepo, gitTokenId, productName) {
+def getLatestReleaseByTag(gitOrg, gitRepo, gitTokenId, productName, gaReleaseTagRef) {
     def latestRelease = ""
     def url = "https://api.github.com/repos/${gitOrg}/${gitRepo}/git/refs/tags"
 
     def (code, releases) = gitFetch(url, gitTokenId)
     if (code != 200) {
-        error "[ERROR] Failed to retrieve tags for:${productName}. The :${gitRepo} repository does not have any tags available"
+      error "[ERROR] Failed to retrieve tags for:${productName}. The :${gitRepo} repository does not have any tags available"
     }
 
-    if (productName == "fuse") {
-        // Retrieve only Fuse's GA releases
-        releases = releases.findAll { release -> release.ref.contains("-redhat-") }
-    }
-
+    // Retrieve GA releases only
+    releases = releases.findAll { release -> release.ref.contains(gaReleaseTagRef) }
     latestRelease = releases.last().ref
     latestRelease = latestRelease.minus("refs/tags/")
 
@@ -104,11 +101,11 @@ def getLatestReleaseByRelease(gitOrg, gitRepo, gitTokenId, productName) {
 }
 
 //Gets the latest release of a product from the project repository
-def getLatestRelease(gitOrg, gitRepo, gitTokenId, releaseFetchMethod) {
+def getLatestRelease(gitOrg, gitRepo, gitTokenId, releaseFetchMethod, gaReleaseTagRef) {
     println "[INFO] Getting latest release for:${productName}"
 
     if (releaseFetchMethod == "tag") {
-        return getLatestReleaseByTag(gitOrg, gitRepo, gitTokenId, productName)
+        return getLatestReleaseByTag(gitOrg, gitRepo, gitTokenId, productName, gaReleaseTagRef)
     } else {
         return getLatestReleaseByRelease(gitOrg, gitRepo, gitTokenId, productName)
     }
@@ -236,6 +233,7 @@ def productVersionLocation = params.productVersionLocation
 def productVersionIdentifier = params.productVersionIdentifier
 def nextBranch = params.installationProductBranch ?: "${productName}-next"
 def installationManifestFile = './evals/inventories/group_vars/all/manifest.yaml'
+def gaReleaseTagRef = params.gaReleaseTagRef ?: ''
 
 currentBuild.displayName = "${currentBuild.displayName} ${productName}"
 
@@ -264,7 +262,7 @@ node {
     }
 
     stage('Fetch Latest GitHub Release') {
-        latestRelease = getLatestRelease(projectOrg, projectRepo, githubToken, releaseFetchMethod)
+        latestRelease = getLatestRelease(projectOrg, projectRepo, githubToken, releaseFetchMethod, gaReleaseTagRef)
         if (!latestRelease) {
             error "[ERROR] Unable to retrieve latest release version!"
         }

--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -22,6 +22,7 @@ generate_inline_script_job $SCRIPTS_DIR/../jobs/repos/repos-delete-branches-and-
 generate_inline_script_job $SCRIPTS_DIR/../jobs/repos/repos-delete-docker-image-tags/repos-delete-docker-image-tags.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/discovery/3scale.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/discovery/backup-container.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/discovery/codeready.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/discovery/fuse.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/discovery/fuse-online.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/discovery/gitea.yaml
@@ -32,6 +33,7 @@ generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/discovery/web
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/discovery/amq-online.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/branch/3scale-next.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/branch/backup-container-next.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/branch/codeready-next.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/branch/fuse-next.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/branch/fuse-online-next.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/release-monitoring/branch/gitea-next.yaml


### PR DESCRIPTION
## Motivation
Automate service discovery for codeready

## What
- Add discovery job for codeready GA releases
  - Releases for codeready should be fetched by [tags](https://github.com/redhat-developer/codeready-workspaces-deprecated/tags).
  - Tags should be filtered by `GA` to only get the GA releases.
- Add branch job for the codeready release to create the codeready-next branch in the installation repo.
- Added param `gaReleaseTagRef` which will be used to filter out the `GA` releases from the repo's tags.

**NOTE**: The image tag for the codeready images are not locked down by a version in each release. They're tagged as `latest` by default ([1.0.0.GA](https://github.com/redhat-developer/codeready-workspaces-deprecated/blob/1.0.0.GA/operator-installer/deploy.sh#L68), [1.0.1.GA](https://github.com/redhat-developer/codeready-workspaces-deprecated/blob/1.0.1.GA/operator-installer/deploy.sh#L6)).

Test PR: https://github.com/integr8ly/installation/pull/467/files