### PR TITLE
Call smoke test with proper admin user on POC

### DIFF
--- a/jobs/integr8ly/qe-poc-master-general.yaml
+++ b/jobs/integr8ly/qe-poc-master-general.yaml
@@ -138,8 +138,8 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                             string(name: 'REPOSITORY', value: "${TEST_SUITES_REPOSITORY}"),
                             string(name: 'BRANCH', value: "${TEST_SUITES_BRANCH}"),
                             string(name: 'CLUSTER_URL', value: "${CLUSTER_URL}"),
-                            string(name: 'ADMIN_USERNAME', value: 'admin@example.com'),
-                            string(name: 'ADMIN_PASSWORD', value: 'Password1')]).result
+                            string(name: 'ADMIN_USERNAME', value: "${OC_USER}"),
+                            string(name: 'ADMIN_PASSWORD', value: "${OC_PASSWORD}")]).result
                                 
                         println "Build finished with ${buildStatus}"
                             


### PR DESCRIPTION
## Motivation & Why
<!-- Add references to relevant tickets or a short description of what motivated you to do it. -->
There is no 'admin' user on QE POC cluster. We need to use some other user when calling smoke tests.

## What & How
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Using user from input parameters of the job

## Verification Steps

jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/qe-poc-master-general.yaml

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO