### PR TITLE
Added EVALS_PASSWORD parameter

### DIFF
--- a/jobs/integr8ly/browser-based-test-executor.yaml
+++ b/jobs/integr8ly/browser-based-test-executor.yaml
@@ -33,6 +33,10 @@
           default: 'evals11@example.com'
           description: 'Evals account email address used to access the available consoles'
       - string:
+          name: EVALS_PASSWORD
+          default: 'Password1'
+          description: 'Evals user password'
+      - string:
           name: TEST_TO_RUN
           default: 
           description: 'Specific test to run (by default all of the tests are executed), e.g. "ui-testsuite/tests/20_apicurito/apicurito-console-login.js"'

--- a/jobs/integr8ly/browser-based-testsuite-pipeline.yaml
+++ b/jobs/integr8ly/browser-based-testsuite-pipeline.yaml
@@ -32,6 +32,10 @@
           name: EVALS_USERNAME
           default: 'evals11@example.com'
           description: 'Evals account email address used to access the available consoles'
+      - string:
+          name: EVALS_PASSWORD
+          default: 'Password1'
+          description: 'Evals user password'
     dsl: |
         timeout(60) { ansiColor('gnome-terminal') { timestamps {
 

--- a/jobs/integr8ly/pds-general.yaml
+++ b/jobs/integr8ly/pds-general.yaml
@@ -175,6 +175,7 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                                 string(name: 'CLUSTER_URL', value: "https://master.${YOURCITY}.openshiftworkshop.com"),
                                 string(name: 'ADMIN_USERNAME', value: 'admin@example.com'),
                                 string(name: 'ADMIN_PASSWORD', value: 'Password1'),
+                                string(name: 'EVALS_PASSWORD', value: 'Password1'),
                                 string(name: 'EVALS_USERNAME', value: 'evals23@example.com')]).result
                             
                             println "Build finished with ${buildStatus}"

--- a/jobs/integr8ly/qe-poc-master-general.yaml
+++ b/jobs/integr8ly/qe-poc-master-general.yaml
@@ -153,10 +153,11 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                         buildStatus = build(job: 'browser-based-testsuite-pipeline', propagate: false, parameters: [
                             string(name: 'REPOSITORY', value: "${TEST_SUITES_REPOSITORY}"),
                             string(name: 'BRANCH', value: "${TEST_SUITES_BRANCH}"),
-                            string(name: 'WEBAPP_URL', value: "https://tutorial-web-app-webapp.${CLUSTER_URI}"),
+                            string(name: 'WEBAPP_URL', value: "https://tutorial-web-app-webapp.apps.${CLUSTER_URI}"),
                             string(name: 'CLUSTER_URL', value: "${CLUSTER_URL}"),
-                            string(name: 'ADMIN_USERNAME', value: 'admin@example.com'),
-                            string(name: 'ADMIN_PASSWORD', value: 'Password1'),
+                            string(name: 'ADMIN_USERNAME', value: "${OC_USER}"),
+                            string(name: 'ADMIN_PASSWORD', value: "${OC_PASSWORD}"),
+                            string(name: 'EVALS_PASSWORD', value: 'Password1'),
                             string(name: 'EVALS_USERNAME', value: 'evals11@example.com')]).result
                             
                         println "Build finished with ${buildStatus}"
@@ -173,8 +174,8 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                             string(name: 'REPOSITORY', value: "${TEST_SUITES_REPOSITORY}"),
                             string(name: 'BRANCH', value: "${TEST_SUITES_BRANCH}"),
                             string(name: 'CLUSTER_URL', value: "${CLUSTER_URL}"),
-                            string(name: 'ADMIN_USERNAME', value: 'admin@example.com'),
-                            string(name: 'ADMIN_PASSWORD', value: 'Password1'),
+                            string(name: 'ADMIN_USERNAME', value: "${OC_USER}"),
+                            string(name: 'ADMIN_PASSWORD', value: "${OC_PASSWORD}"),
                             string(name: 'EVALS_USERNAME', value: 'evals11@example.com')]).result
                             
                         println "Build finished with ${buildStatus}"


### PR DESCRIPTION
## Motivation & Why
<!-- Add references to relevant tickets or a short description of what motivated you to do it. -->
The param needs to be added due to https://gitlab.cee.redhat.com/integreatly-qe/integreatly-qe/merge_requests/96

## What & How
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Added the parameter to the browser test suite jobs. Also updated PDS and POC general jobs to call the browser based testsuite with the param set.

## Verification Steps

jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/browser-based-testsuite-pipeline.yaml
jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/browser-based-test-executor.yaml
jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/pds-general.yaml
jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/qe-poc-master-general.yaml

Please run the 'update' command as well. It does not work on my machine due to some cert issues.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO