### PR TITLE
Remove label score

### DIFF
--- a/jobs/release-monitoring/branch/3scale-next.yaml
+++ b/jobs/release-monitoring/branch/3scale-next.yaml
@@ -16,7 +16,7 @@
       - string:
           name: 'productName'
           default: '3scale'
-          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
     pipeline-scm:
       script-path: jobs/release-monitoring/branch/Jenkinsfile
       scm:

--- a/jobs/release-monitoring/branch/amq-online-next.yaml
+++ b/jobs/release-monitoring/branch/amq-online-next.yaml
@@ -16,7 +16,7 @@
       - string:
           name: 'productName'
           default: 'amq-online'
-          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
     pipeline-scm:
       script-path: jobs/release-monitoring/branch/Jenkinsfile
       scm:

--- a/jobs/release-monitoring/branch/fuse-next.yaml
+++ b/jobs/release-monitoring/branch/fuse-next.yaml
@@ -16,7 +16,7 @@
       - string:
           name: 'productName'
           default: 'fuse'
-          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
     pipeline-scm:
       script-path: jobs/release-monitoring/branch/Jenkinsfile
       scm:

--- a/jobs/release-monitoring/branch/fuse-online-next.yaml
+++ b/jobs/release-monitoring/branch/fuse-online-next.yaml
@@ -16,7 +16,7 @@
       - string:
           name: 'productName'
           default: 'fuse-online'
-          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
     pipeline-scm:
       script-path: jobs/release-monitoring/branch/Jenkinsfile
       scm:

--- a/jobs/release-monitoring/branch/gitea-next.yaml
+++ b/jobs/release-monitoring/branch/gitea-next.yaml
@@ -16,7 +16,7 @@
       - string:
           name: 'productName'
           default: 'gitea'
-          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
     pipeline-scm:
       script-path: jobs/release-monitoring/branch/Jenkinsfile
       scm:

--- a/jobs/release-monitoring/branch/middleware-monitoring-next.yaml
+++ b/jobs/release-monitoring/branch/middleware-monitoring-next.yaml
@@ -16,7 +16,7 @@
       - string:
           name: 'productName'
           default: 'middleware-monitoring'
-          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
     pipeline-scm:
       script-path: jobs/release-monitoring/branch/Jenkinsfile
       scm:

--- a/jobs/release-monitoring/branch/msbroker-next.yaml
+++ b/jobs/release-monitoring/branch/msbroker-next.yaml
@@ -16,7 +16,7 @@
       - string:
           name: 'productName'
           default: 'msbroker'
-          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
     pipeline-scm:
       script-path: jobs/release-monitoring/branch/Jenkinsfile
       scm:

--- a/jobs/release-monitoring/branch/rhsso-next.yaml
+++ b/jobs/release-monitoring/branch/rhsso-next.yaml
@@ -16,7 +16,7 @@
       - string:
           name: 'productName'
           default: 'rhsso'
-          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
     pipeline-scm:
       script-path: jobs/release-monitoring/branch/Jenkinsfile
       scm:

--- a/jobs/release-monitoring/branch/webapp-next.yaml
+++ b/jobs/release-monitoring/branch/webapp-next.yaml
@@ -16,7 +16,7 @@
       - string:
           name: 'productName'
           default: 'webapp'
-          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
     pipeline-scm:
       script-path: jobs/release-monitoring/branch/Jenkinsfile
       scm:

--- a/jobs/release-monitoring/discovery/fuse-online.yaml
+++ b/jobs/release-monitoring/discovery/fuse-online.yaml
@@ -20,12 +20,12 @@
       - string:
           name: 'projectRepo'
           default: 'fuse-online-install'
-          description: '[REQUIRED] github project repostirory'
+          description: '[REQUIRED] github project repository'
           read-only: true
       - string:
           name: 'productName'
           default: 'fuse-online'
-          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
       - string:
           name: 'releaseFetchMethod'

--- a/jobs/release-monitoring/discovery/fuse.yaml
+++ b/jobs/release-monitoring/discovery/fuse.yaml
@@ -20,12 +20,12 @@
       - string:
           name: 'projectRepo'
           default: 'application-templates'
-          description: '[REQUIRED] github project repostirory'
+          description: '[REQUIRED] github project repository'
           read-only: true
       - string:
           name: 'productName'
           default: 'fuse'
-          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
       - string:
           name: 'releaseFetchMethod'

--- a/jobs/release-monitoring/discovery/github/Jenkinsfile
+++ b/jobs/release-monitoring/discovery/github/Jenkinsfile
@@ -111,31 +111,6 @@ def getLatestRelease(gitOrg, gitRepo, gitTokenId, releaseFetchMethod, gaReleaseT
     }
 }
 
-def getLabelScore(label) {
-    if (!label) {
-        return 0
-    }
-
-    def score = 0
-    def scores = [
-            'GA': 1,
-            'redhat': 1
-    ]
-    def parts = label.tokenize('-')
-
-    parts.each { part ->
-        if (scores.containsKey(part)) {
-            score += scores[part]
-        }
-
-        if (!scores.containsKey(part) && part.isInteger()) {
-            score += part.toInteger()
-        }
-    }
-
-    return score
-}
-
 //checks if current semver is lower than the supposed latest one
 def hasNewGARelease(currentVersion, newVersion, productName) {
     def current = ""
@@ -155,8 +130,6 @@ def hasNewGARelease(currentVersion, newVersion, productName) {
     def latestMinor = latest[1] as Integer
     def currentPatch = current[2] as Integer
     def latestPatch = latest[2] as Integer
-    def currentLabel = current[3]
-    def latestLabel = latest[3]
 
     def previousVer = 0
     def currentVer = 0
@@ -174,13 +147,6 @@ def hasNewGARelease(currentVersion, newVersion, productName) {
         if (previousDiff && currentDiff) {
             return true
         }
-    }
-
-    def currentLabelScore = getLabelScore(currentLabel)
-    def latestLabelScore = getLabelScore(latestLabel)
-
-    if (latestLabelScore > currentLabelScore) {
-        return true
     }
 
     return false

--- a/jobs/release-monitoring/discovery/github/Jenkinsfile
+++ b/jobs/release-monitoring/discovery/github/Jenkinsfile
@@ -167,12 +167,6 @@ def when(boolean condition, body) {
     }
 }
 
-def ensureEvalsDir() {
-    if (!fileExists("evals")) {
-        sh "ln -s . evals"
-    }
-}
-
 def updateManifestVariable(manifestFileTxt, name, value) {
     if (name && value) {
         println("Updating manifest variable: name = ${name}, value = ${value}")
@@ -198,8 +192,8 @@ def releaseFetchMethod = params.releaseFetchMethod
 def productVersionLocation = params.productVersionLocation
 def productVersionIdentifier = params.productVersionIdentifier
 def nextBranch = params.installationProductBranch ?: "${productName}-next"
-def installationManifestFile = './evals/inventories/group_vars/all/manifest.yaml'
 def gaReleaseTagRef = params.gaReleaseTagRef ?: ''
+def installationManifestFile = './inventories/group_vars/all/manifest.yaml'
 
 currentBuild.displayName = "${currentBuild.displayName} ${productName}"
 
@@ -210,7 +204,6 @@ node {
         cleanWs()
         dir('installation') {
             checkoutGitRepo(installationGitUrl, installationGitRef, githubCredentialsID)
-            ensureEvalsDir()
             releaseConfig = readYaml file: installationManifestFile
         }
     }


### PR DESCRIPTION
## What
- Remove `getLabelScore` from the Jenkins discovery pipeline.
  - The label passed to `getLabelScore()` is removed [here](https://github.com/integr8ly/ci-cd/blob/master/jobs/release-monitoring/discovery/github/Jenkinsfile#L148-L152) therefore this will always return a score of 0.
- Fix typos in the description of the productName and productRepo parameters
- Remove `ensureEvalsDir()`.
  - The evals directory no longer exists on the [installation](https://github.com/integr8ly/installation/commit/8af2bb98a3fe55fb3a9fa1766f845c39d1389121) repository.