### PR TITLE
Fixed MASTERS_URLS parameter removal

### DIFF
--- a/jobs/integr8ly/uninstallation-pipeline.yaml
+++ b/jobs/integr8ly/uninstallation-pipeline.yaml
@@ -113,10 +113,8 @@
                                 sed -i 's/ansible_user=ec2-user/ansible_user=${ANSIBLE_USER}/g' ./evals/inventories/hosts
                             """
                             
-                            String masterUrls = MASTER_URLS.replaceAll(~/,[\s]*/, '\\\\n')
-                            
                             sh """
-                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n${masterUrls}@;P;D' ./evals/inventories/hosts
+                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n${MASTER_URL}@;P;D' ./evals/inventories/hosts
                             """
                             
                             String output = readFile('./evals/inventories/hosts')


### PR DESCRIPTION
## Motivation & Why
<!-- Add references to relevant tickets or a short description of what motivated you to do it. -->

MASTER_URLS parameter no longer exists. References need to be removed

## What & How
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Using MASTER_URL parameter instead.

## Verification Steps

jenkins-jobs --conf jenkins_jobs.ini test integr8ly/uninstallation-pipeline.yaml

I ran this on Jenkins here:
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/all/job/uninstallation-pipeline/805/

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO

