### PR TITLE
Added evals dir back to work with 1.2.2 release

### DIFF
--- a/jobs/integr8ly/installation-pipeline.yaml
+++ b/jobs/integr8ly/installation-pipeline.yaml
@@ -129,18 +129,18 @@
                     stage('Prepare environment') {
                         dir('installation') {
                             sh """
-                                cp ./inventories/hosts.template ./inventories/hosts
-                                sed -i 's/ansible_user=ec2-user/ansible_user=${ANSIBLE_USER}/g' ./inventories/hosts
+                                cp ./evals/inventories/hosts.template ./evals/inventories/hosts
+                                sed -i 's/ansible_user=ec2-user/ansible_user=${ANSIBLE_USER}/g' ./evals/inventories/hosts
                             """
                             
                             // not needed - there is only one master node on PDS
                             // String masterUrls = MASTER_URLS.replaceAll(~/,[\s]*/, '\\\\n')
                             
                             sh """
-                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n${MASTER_URL}@;P;D' ./inventories/hosts
+                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n${MASTER_URL}@;P;D' ./evals/inventories/hosts
                             """
                             
-                            String output = readFile('./inventories/hosts')
+                            String output = readFile('./evals/inventories/hosts')
                             println output
                             
                             if (BRANCH == 'master') {   
@@ -155,7 +155,7 @@
                     } // stage
                     
                     stage('Execute playbook') {
-                        dir('installation') {
+                        dir('installation/evals') {
                             
                             String ansibleParams = ''
                             if(GH_CLIENT_ID && GH_CLIENT_SECRET) {


### PR DESCRIPTION
## Motivation & Why
<!-- Add references to relevant tickets or a short description of what motivated you to do it. -->

Added evals dir back so that the pipeline works with both v1.2 and master branches.

## What & How
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Added evals dir back to relevant paths.

## Verification Steps

jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/installation-pipeline.yaml

Jenkins run:
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/all/job/installation-pipeline/675/

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->
