### PR TITLE
Add job for installing integreatly on OSD via ansible tower

### DIFF
--- a/jobs/openshift/cluster/integreatly/install/Jenkinsfile
+++ b/jobs/openshift/cluster/integreatly/install/Jenkinsfile
@@ -62,8 +62,8 @@ node('cirhos_rhel7') {
                   openshift_master_public_url: ${installerOptions.openshiftMasterUrl}
                   openshift_username: ${installerOptions.clusterAdminUsername}
                   openshift_password: ${installerOptions.clusterAdminPassword}
-                  integreatly_project_bootstrap_cluster_scm_url: ${installerOptions.installerGitUrl}
-                  integreatly_project_bootstrap_cluster_scm_branch: ${installerOptions.installerGitBranch}
+                  integreatly_project_install_scm_url: ${installerOptions.installerGitUrl}
+                  integreatly_project_install_scm_branch: ${installerOptions.installerGitBranch}
                   eval_seed_users_count: ${installerOptions.userCount}
                   eval_self_signed_certs: '${installerOptions.selfSignedCerts}'
                   integreatly_inventory_source_aws_credentials: ${installerOptions.awsCredentials}"""

--- a/jobs/openshift/cluster/integreatly/install/Jenkinsfile
+++ b/jobs/openshift/cluster/integreatly/install/Jenkinsfile
@@ -1,0 +1,74 @@
+#!groovy
+
+def installerOptions = [:]
+
+def verifyInstallerOptions(installerOptions) {
+    if (!installerOptions.clusterName || !installerOptions.openshiftMasterUrl || !installerOptions.clusterAdminUsername || !installerOptions.clusterAdminPassword ||
+        !installerOptions.installerGitUrl || !installerOptions.installerGitBranch) {
+        def userInput = input message: 'Installer Options', parameters: [
+            string(defaultValue: (installerOptions.clusterName ?: ''), description: 'Cluster name', name: 'clusterName'),
+            string(defaultValue: (installerOptions.openshiftMasterUrl ?: ''), description: 'OpenShift cluster public URL', name: 'openshiftMasterUrl'),
+            string(defaultValue: (installerOptions.clusterAdminUsername ?: 'integreatly'), description: 'OpenShift cluster admin username', name: 'clusterAdminUsername'),
+            string(defaultValue: (installerOptions.clusterAdminPassword ?: 'Password1'), description: 'OpenShift cluster admin password', name: 'clusterAdminPassword'),
+            string(defaultValue: (installerOptions.installerGitUrl ?: 'https://github.com/integr8ly/installation.git'), description: 'Integreatly installer Git URL', name: 'installerGitUrl'),
+            string(defaultValue: (installerOptions.installerGitBranch ?: 'master'), description: 'Integreatly installer Git branch', name: 'installerGitBranch'),
+        ]
+        installerOptions.clusterName = userInput.clusterName
+        installerOptions.openshiftMasterUrl = userInput.openshiftMasterUrl
+        installerOptions.clusterAdminUsername = userInput.clusterAdminUsername
+        installerOptions.clusterAdminPassword = userInput.clusterAdminPassword
+        installerOptions.installerGitUrl = userInput.installerGitUrl
+        installerOptions.installerGitBranch = userInput.installerGitBranch
+        verifyInstallerOptions(installerOptions)
+    }
+}
+
+stage("Verify Installation Options") {
+    installerOptions.clusterName = params.clusterName
+    installerOptions.openshiftMasterUrl = params.openshiftMasterUrl
+    installerOptions.clusterAdminUsername = params.clusterAdminUsername
+    installerOptions.clusterAdminPassword = params.clusterAdminPassword
+    installerOptions.installerGitUrl = params.installerGitUrl
+    installerOptions.installerGitBranch = params.installerGitBranch
+    installerOptions.userCount = params.userCount
+    installerOptions.selfSignedCerts = params.selfSignedCerts ? 'true': 'false'
+    installerOptions.awsCredentials = 'fheng.AWS'
+
+    verifyInstallerOptions(installerOptions)
+    println "Installer Options: ${installerOptions}"
+    currentBuild.displayName = "${currentBuild.displayName} ${installerOptions.clusterName}"
+    currentBuild.description = """clusterName: ${installerOptions.clusterName}\nopenshiftMasterUrl: ${installerOptions.openshiftMasterUrl}
+                                \nopenshiftUsername: ${installerOptions.clusterAdminUsername}\nopenshiftPassword: ${installerOptions.clusterAdminPassword}
+                                \ninstallerGitUrl: ${installerOptions.installerGitUrl}\ninstallerGitBranch: ${installerOptions.installerGitBranch}
+                                \nselfSignedCerts: ${installerOptions.selfSignedCerts}\nawsCredentials:${installerOptions.awsCredentials}"""
+}
+
+node('cirhos_rhel7') {
+    cleanWs()
+    stage('Install Integreatly') {
+        if (params.dryRun) {
+            println("Would call ansibleTower Integreatly Install Workflow template with the following installer options: ${installerOptions}")
+        } else {
+            wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
+              ansibleTower(
+                towerServer: 'Dev Tower',
+                jobTemplate: 'Integreatly Install Workflow',
+                templateType: 'workflow',
+                importTowerLogs: true,
+                removeColor: false,
+                verbose: true,
+                extraVars: """---
+                  cluster_name: ${installerOptions.clusterName}
+                  openshift_master_public_url: ${installerOptions.openshiftMasterUrl}
+                  openshift_username: ${installerOptions.clusterAdminUsername}
+                  openshift_password: ${installerOptions.clusterAdminPassword}
+                  integreatly_project_bootstrap_cluster_scm_url: ${installerOptions.installerGitUrl}
+                  integreatly_project_bootstrap_cluster_scm_branch: ${installerOptions.installerGitBranch}
+                  eval_seed_users_count: ${installerOptions.userCount}
+                  eval_self_signed_certs: '${installerOptions.selfSignedCerts}'
+                  integreatly_inventory_source_aws_credentials: ${installerOptions.awsCredentials}"""
+              )
+            }
+        }
+    }
+}

--- a/jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-install.yaml
+++ b/jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-install.yaml
@@ -1,0 +1,51 @@
+---
+- job:
+    name: openshift-cluster-integreatly-install
+    display-name: 'Openshift Cluster Integreatly Install'
+    project-type: pipeline
+    parameters:
+      - string:
+          name: 'clusterName'
+          default: ''
+          description: '[REQUIRED] The name of the target cluster to install Integreatly against'
+      - string:
+          name: 'openshiftMasterUrl'
+          default: ''
+          description: '[REQUIRED] The public URL of the target OpenShift cluster'
+      - string:
+          name: 'clusterAdminUsername'
+          default: 'integreatly'
+          description: '[REQUIRED] Username of the cluster admin account'
+      - string:
+          name: 'clusterAdminPassword'
+          default: 'Password1'
+          description: '[REQUIRED] Password of the cluster admin account'
+      - string:
+          name: 'installerGitUrl'
+          default: 'https://github.com/integr8ly/installation.git'
+          description: '[REQUIRED] Integreatly installer Git URL'
+      - string:
+          name: 'installerGitBranch'
+          default: 'master'
+          description: '[REQUIRED] The name of the git branch to be used for the Integreatly installer'
+      - string:
+          name: 'userCount'
+          default: '50'
+          description: '[OPTIONAL] The number of users to pre-seed in the environment'
+      - bool:
+          name: 'selfSignedCerts'
+          default: false
+          description: '[OPTIONAL] Set to true if the target OpenShift cluster uses self-signed certs'
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
+    pipeline-scm:
+      script-path: jobs/openshift/cluster/integreatly/install/Jenkinsfile
+      scm:
+        - git:
+            branches:
+              - 'master'
+            url: 'https://github.com/integr8ly/ci-cd.git'
+            skip-tag: true
+            wipe-workspace: false

--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -53,6 +53,7 @@ generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/suites/integreatly/next
 #OpenShift Cluster Jobs
 generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/create/openshift-cluster-create.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/deprovision/openshift-cluster-deprovision.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-install.yaml
 
 #Delorean Folders
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/delorean/folders.yaml


### PR DESCRIPTION
## What
**Installation**
Add a Jenkins job for triggering the `Integreatly Install Workflow` template in Ansible Tower.
Parameters required for the survey of the `Integreatly Install Workflow` template:
- cluster_name
- eval_seed_users_count
- eval_self_signed_certs
- integreatly_inventory_source_aws_credentials
- integreatly_project_bootstrap_cluster_scm_branch
- integreatly_project_bootstrap_cluster_scm_url
- openshift_master_public_url
- openshift_password
- openshift_username