### PR TITLE
ensure job fails on a failed rebase of product next branch

### DIFF
--- a/jobs/release-monitoring/discovery/github/Jenkinsfile
+++ b/jobs/release-monitoring/discovery/github/Jenkinsfile
@@ -270,7 +270,7 @@ node {
                     sh "git rebase origin/${installationGitRef}"
                 } catch (Exception e) {
                     sh "git rebase --abort"
-                    println "We were unable to automatically rebase the target branch '${installationGitRef}' into the source branch '${nextBranch}'. Please fix these conflicts locally and push the changes to ${nextBranch} before running this job again!"
+                    error "[ERROR] We were unable to automatically rebase the target branch '${installationGitRef}' into the source branch '${nextBranch}'. Please fix these conflicts locally and push the changes to ${nextBranch} before running this job again!"
                 }
             }
 


### PR DESCRIPTION
## What
The Jenkins job for the release discovery succeeds even if the `<product>-branch` fails to rebase from master. The job should fail when this happens to ensure that we are able to catch and fix merge conflicts. 