### PR TITLE
Removed hard-coded IP in clean uninstall pipeline

### DIFF
--- a/jobs/integr8ly/clean-uninstallation-pipeline.yaml
+++ b/jobs/integr8ly/clean-uninstallation-pipeline.yaml
@@ -45,7 +45,7 @@
                             """
             
                             sh """
-                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n10.8.248.187@;P;D' ./evals/inventories/hosts
+                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\ntrepel-merrn-1@;P;D' ./evals/inventories/hosts
                             """
                             
                             String output = readFile('./evals/inventories/hosts')


### PR DESCRIPTION
OK, this is slightly better than the previous PR since this string stays if the same in case of cluster recreation.


jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/clean-uninstallation-pipeline.yaml

https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Nightly/job/clean-uninstallation-pipeline/183/