### PR TITLE
cluster params

### DIFF
--- a/jobs/openshift/cluster/create/Jenkinsfile
+++ b/jobs/openshift/cluster/create/Jenkinsfile
@@ -25,6 +25,20 @@ stage("Cluster Options") {
     println "Cluster Options: ${clusterOptions}"
     currentBuild.displayName = "${currentBuild.displayName} ${clusterOptions.name}"
     currentBuild.description = "clusterName: ${clusterOptions.name}\nawsRegion: ${clusterOptions.awsRegion}"
+    clusterOptions.nodes = [
+        'master': [
+            'instance_type': "${master_instance_type}",
+            'group_size': "${master_group_size}"
+        ],
+        'compute': [
+            'instance_type': "${compute_instance_type}",
+            'group_size': "${compute_group_size}"
+        ],
+        'infra': [
+            'instance_type': "${infra_instance_type}",
+            'group_size': "${infra_group_size}"
+        ]
+    ]
 }
 
 node('cirhos_rhel7') {
@@ -34,7 +48,7 @@ node('cirhos_rhel7') {
         if (params.dryRun) {
             println("Would call ansibleTower with: oo_clusterid: ${clusterOptions.name}, oo_sublocation: ${clusterOptions.awsRegion}")
         } else {
-            wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
+            wrap([$class: 'AnsiColorBuildWrapper', colorMapName: 'xterm']) {
                 ansibleTower(
                         towerServer: 'Dev Tower',
                         jobTemplate: 'Provision Cluster',
@@ -46,7 +60,13 @@ node('cirhos_rhel7') {
                     oo_clusterid: ${clusterOptions.name}
                     oo_sublocation: ${clusterOptions.awsRegion}
                     cluster_credential_bundle_aws_name: ${clusterOptions.awsAccountName}
-                    survey_provision_logging: 'false'"""
+                    survey_provision_logging: 'false'
+                    master_instance_size: ${clusterOptions.nodes.master.instance_type}
+                    compute_instance_size: ${clusterOptions.nodes.compute.instance_type}
+                    infra_instance_size: ${clusterOptions.nodes.infra.instance_type}
+                    openshift_aws_master_group_desired_size: ${clusterOptions.nodes.master.group_size}
+                    openshift_aws_compute_group_desired_size: ${clusterOptions.nodes.compute.group_size}
+                    openshift_aws_infra_group_desired_size: ${clusterOptions.nodes.infra.group_size}"""
                 )
             }
         }

--- a/jobs/openshift/cluster/create/openshift-cluster-create.yaml
+++ b/jobs/openshift/cluster/create/openshift-cluster-create.yaml
@@ -22,28 +22,28 @@
           default: false
           description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
       - string:
-          name: master_instance_type
-          default: m4.xlarge
+          name: 'master_instance_type'
+          default: 'm4.xlarge'
           description: '[REQUIRED] the AWS instance type for master node(s)'
       - string:
-          name: compute_instance_type
-          default: m4.xlarge
+          name: 'compute_instance_type'
+          default: 'm4.xlarge'
           description: '[REQUIRED] the AWS instance type for compute node(s)'
       - string:
-          name: infra_instance_type
-          default: m4.xlarge
+          name: 'infra_instance_type'
+          default: 'm4.xlarge'
           description: '[REQUIRED] the AWS instance type for infra node(s)'
       - string:
-          name: master_group_size
-          default: 3
+          name: 'master_group_size'
+          default: '3'
           description: '[REQUIRED] The amount of AWS master nodes to be created'
       - string:
-          name: compute_group_size
-          default: 3
+          name: 'compute_group_size'
+          default: '3'
           description: '[REQUIRED] The amount of AWS compute nodes to be created'
       - string:
-          name: infra_group_size
-          default: 3
+          name: 'infra_group_size'
+          default: '3'
           description: '[REQUIRED] The amount of AWS infra nodes to be created'
     pipeline-scm:
       script-path: jobs/openshift/cluster/create/Jenkinsfile

--- a/jobs/openshift/cluster/create/openshift-cluster-create.yaml
+++ b/jobs/openshift/cluster/create/openshift-cluster-create.yaml
@@ -21,6 +21,30 @@
           name: 'dryRun'
           default: false
           description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
+      - string:
+          name: master_instance_type
+          default: m4.xlarge
+          description: '[REQUIRED] the AWS instance type for master node(s)'
+      - string:
+          name: compute_instance_type
+          default: m4.xlarge
+          description: '[REQUIRED] the AWS instance type for compute node(s)'
+      - string:
+          name: infra_instance_type
+          default: m4.xlarge
+          description: '[REQUIRED] the AWS instance type for infra node(s)'
+      - string:
+          name: master_group_size
+          default: 3
+          description: '[REQUIRED] The amount of AWS master nodes to be created'
+      - string:
+          name: compute_group_size
+          default: 3
+          description: '[REQUIRED] The amount of AWS compute nodes to be created'
+      - string:
+          name: infra_group_size
+          default: 3
+          description: '[REQUIRED] The amount of AWS infra nodes to be created'
     pipeline-scm:
       script-path: jobs/openshift/cluster/create/Jenkinsfile
       scm:

--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -50,6 +50,9 @@ generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/webapp/next/branch.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/webapp/next/discovery.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/suites/integreatly/next/branch.yaml
 
+#OpenShift Cluster Jobs
+generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/create/openshift-cluster-create.yaml
+
 #Delorean Folders
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/delorean/folders.yaml
 


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Adds extra vars for cluster creation:

* master_instance_type
* compute_instance_type
* infra_instance_type
* master_group_size
* compute_group_size
* infra_group_size

Those vars get added into a "nodes" dictionary which contains another dict for each node type (master, compute and infra):

```py
clusterOptions.nodes = {
  'master': {'instance_type': '', 'group_size': ''}
  'compute': {'instance_type': '', 'group_size': ''}
  'infra': {'instance_type': '', 'group_size': ''}
}
```

