### PR TITLE
Add job for uninstalling integreatly on OSD via ansible tower

### DIFF
--- a/jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-uninstall.yaml
+++ b/jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-uninstall.yaml
@@ -1,0 +1,43 @@
+---
+- job:
+    name: openshift-cluster-integreatly-uninstall
+    display-name: 'Openshift Cluster Integreatly Uninstall'
+    project-type: pipeline
+    parameters:
+      - string:
+          name: 'clusterName'
+          default: ''
+          description: '[REQUIRED] The name of the target cluster to uninstall Integreatly against'
+      - string:
+          name: 'openshiftMasterUrl'
+          default: ''
+          description: '[REQUIRED] The public URL of the target OpenShift cluster'
+      - string:
+          name: 'clusterAdminUsername'
+          default: 'integreatly'
+          description: '[REQUIRED] Username of the cluster admin account'
+      - string:
+          name: 'clusterAdminPassword'
+          default: 'Password1'
+          description: '[REQUIRED] Password of the cluster admin account'
+      - string:
+          name: 'uninstallerGitUrl'
+          default: 'https://github.com/integr8ly/installation.git'
+          description: '[REQUIRED] Integreatly uninstaller Git URL'
+      - string:
+          name: 'uninstallerGitBranch'
+          default: 'master'
+          description: '[REQUIRED] The name of the git branch to be used for the Integreatly uninstaller'
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
+    pipeline-scm:
+      script-path: jobs/openshift/cluster/integreatly/uninstall/Jenkinsfile
+      scm:
+        - git:
+            branches:
+              - 'master'
+            url: 'https://github.com/integr8ly/ci-cd.git'
+            skip-tag: true
+            wipe-workspace: false

--- a/jobs/openshift/cluster/integreatly/uninstall/Jenkinsfile
+++ b/jobs/openshift/cluster/integreatly/uninstall/Jenkinsfile
@@ -1,0 +1,67 @@
+#!groovy
+
+def uninstallerOptions = [:]
+
+def verifyUninstallerOptions(uninstallerOptions) {
+    if (!uninstallerOptions.clusterName || !uninstallerOptions.openshiftMasterUrl || !uninstallerOptions.clusterAdminUsername || !uninstallerOptions.clusterAdminPassword ||
+        !uninstallerOptions.uninstallerGitUrl || !uninstallerOptions.uninstallerGitBranch) {
+        def userInput = input message: 'Installer Options', parameters: [
+            string(defaultValue: (uninstallerOptions.clusterName ?: ''), description: 'Cluster name', name: 'clusterName'),
+            string(defaultValue: (uninstallerOptions.openshiftMasterUrl ?: ''), description: 'OpenShift cluster public URL', name: 'openshiftMasterUrl'),
+            string(defaultValue: (uninstallerOptions.clusterAdminUsername ?: 'integreatly'), description: 'OpenShift cluster admin username', name: 'clusterAdminUsername'),
+            string(defaultValue: (uninstallerOptions.clusterAdminPassword ?: 'Password1'), description: 'OpenShift cluster admin password', name: 'clusterAdminPassword'),
+            string(defaultValue: (uninstallerOptions.uninstallerGitUrl ?: 'https://github.com/integr8ly/installation.git'), description: 'Integreatly uninstaller Git URL', name: 'uninstallerGitUrl'),
+            string(defaultValue: (uninstallerOptions.uninstallerGitBranch ?: 'master'), description: 'Integreatly uninstaller Git branch', name: 'uninstallerGitBranch'),
+        ]
+        uninstallerOptions.clusterName = userInput.clusterName
+        uninstallerOptions.openshiftMasterUrl = userInput.openshiftMasterUrl
+        uninstallerOptions.clusterAdminUsername = userInput.clusterAdminUsername
+        uninstallerOptions.clusterAdminPassword = userInput.clusterAdminPassword
+        uninstallerOptions.uninstallerGitUrl = userInput.uninstallerGitUrl
+        uninstallerOptions.uninstallerGitBranch = userInput.uninstallerGitBranch
+        verifyUninstallerOptions(uninstallerOptions)
+    }
+}
+
+stage("Verify Uninstallation Options") {
+    uninstallerOptions.clusterName = params.clusterName
+    uninstallerOptions.openshiftMasterUrl = params.openshiftMasterUrl
+    uninstallerOptions.clusterAdminUsername = params.clusterAdminUsername
+    uninstallerOptions.clusterAdminPassword = params.clusterAdminPassword
+    uninstallerOptions.uninstallerGitUrl = params.uninstallerGitUrl
+    uninstallerOptions.uninstallerGitBranch = params.uninstallerGitBranch
+
+    verifyUninstallerOptions(uninstallerOptions)
+    println "Installer Options: ${uninstallerOptions}"
+    currentBuild.displayName = "${currentBuild.displayName} ${uninstallerOptions.clusterName}"
+    currentBuild.description = """clusterName: ${uninstallerOptions.clusterName}\nopenshiftMasterUrl: ${uninstallerOptions.openshiftMasterUrl}
+                                \nopenshiftUsername: ${uninstallerOptions.clusterAdminUsername}\nopenshiftPassword: ${uninstallerOptions.clusterAdminPassword}
+                                \nuninstallerGitUrl: ${uninstallerOptions.installerGitUrl}\nuninstallerGitBranch: ${uninstallerOptions.installerGitBranch}"""
+}
+
+node('cirhos_rhel7') {
+    cleanWs()
+    stage('Uninstall Integreatly') {
+        if (params.dryRun) {
+            println("Would call ansibleTower Integreatly Uninstall job template with the following unnstallation options: ${uninstallerOptions}")
+        } else {
+            wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
+              ansibleTower(
+                towerServer: 'Dev Tower',
+                jobTemplate: 'Integreatly Uninstall Template',
+                templateType: 'job',
+                importTowerLogs: true,
+                removeColor: false,
+                verbose: true,
+                extraVars: """---
+                  cluster_name: ${uninstallerOptions.clusterName}
+                  openshift_master_public_url: ${uninstallerOptions.openshiftMasterUrl}
+                  openshift_username: ${uninstallerOptions.clusterAdminUsername}
+                  openshift_password: ${uninstallerOptions.clusterAdminPassword}
+                  integreatly_project_uninstall_scm_url: ${uninstallerOptions.uninstallerGitUrl}
+                  integreatly_project_uninstall_scm_branch: ${uninstallerOptions.uninstallerGitBranch}"""
+              )
+            }
+        }
+    }
+}

--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -54,6 +54,7 @@ generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/suites/integreatly/next
 generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/create/openshift-cluster-create.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/deprovision/openshift-cluster-deprovision.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-install.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-uninstall.yaml
 
 #Delorean Folders
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/delorean/folders.yaml


### PR DESCRIPTION
## What
Add a Jenkins job for uninstalling integreatly on OSD via ansible tower. This Job will call the workflow `Integreatly Uninstall Template` in the Ansible Tower dev instance with the following parameters: 
  - cluster_name
  - openshift_master_public_url
  - openshift_username
  - openshift_password
  - integreatly_project_uninstall_scm_url
  - integreatly_project_uninstall_scm_branch