### PR TITLE
enabling sqs trigger

### DIFF
--- a/jobs/delorean/misc/github-events/github-events.yaml
+++ b/jobs/delorean/misc/github-events/github-events.yaml
@@ -4,6 +4,13 @@
     display-name: 'GitHub Events Monitor'
     project-type: pipeline
     concurrent: true
+    triggers:
+    - raw:
+        xml: |
+          <io.relution.jenkins.awssqs.SQSTrigger plugin="aws-sqs@2.0.1">
+            <spec></spec>
+            <queueUuid>b122060c-a518-4e46-939c-7ba8cbd8ce54</queueUuid>
+          </io.relution.jenkins.awssqs.SQSTrigger>
     pipeline-scm:
       script-path: jobs/delorean/misc/github-events/Jenkinsfile
       scm:


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Adds sqs build trigger in github events job 

## Verificaiton

* Disable the sqs build trigger
* Run `jenkins-jobs --conf jenkins_job.ini test jobs/delorean/misc/github-events/github-events.yaml`
* Check if the sqs build trigger is properly set 