### PR TITLE
changed cluster_url param in poc nightly trigger to yourcity

### DIFF
--- a/jobs/integr8ly/poc-testing-executor.yaml
+++ b/jobs/integr8ly/poc-testing-executor.yaml
@@ -42,8 +42,9 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             default: master
             description: "Branch of a repository of Integreatly test suites"
         - string:
-            name: CLUSTER_URL
-            description: "URL of cluster for installation."
+            name: YOURCITY
+            default: integreatly-qe.opentry.me
+            description: "City or Customer (5 char min.) plus the generated hash, e.g. qebrno-5d10 [required]"
         - string:
             name: MASTER_URLS
             description: "Comma separated list of URLs for master nodes of target cluster to be used in Ansible inventory file"
@@ -75,8 +76,8 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                         if (!MASTER_URLS) {
                             throw new hudson.AbortException('MASTER_URLS parameter is required!')
                         } // if
-                        if (!CLUSTER_URL) {
-                            throw new hudson.AbortException('CLUSTER_URL parameter is required!')
+                        if (!YOURCITY) {
+                            throw new hudson.AbortException('YOURCITY parameter is required!')
                         } // if
                         if (!OC_USER) {
                             throw new hudson.AbortException('OC_USER parameter is required!')
@@ -161,7 +162,7 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             build job: 'poc-uninstall', parameters: [
                 string(name: 'REPOSITORY', value: "${INSTALLATION_REPOSITORY}"),
                 string(name: 'BRANCH', value: "${INSTALLATION_BRANCH}"),
-                string(name: 'CLUSTER_URL', value: "${CLUSTER_URL}"),
+                string(name: 'CLUSTER_URL', value: "https://${YOURCITY}"),
                 string(name: 'ANSIBLE_USER', value: "${ANSIBLE_USER}"),
                 string(name: 'MASTER_URLS', value: "${MASTER_URLS}"),
                 string(name: 'OC_USER', value: "${OC_USER}"),
@@ -174,7 +175,7 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             build job: 'poc-install', parameters: [
                 string(name: 'REPOSITORY', value: "${INSTALLATION_REPOSITORY}"),
                 string(name: 'BRANCH', value: "${INSTALLATION_BRANCH}"),
-                string(name: 'CLUSTER_URL', value: "${CLUSTER_URL}"),
+                string(name: 'CLUSTER_URL', value: "https://${YOURCITY}"),
                 string(name: 'GH_CLIENT_ID', value: "${GH_CLIENT_ID}"),
                 string(name: 'GH_CLIENT_SECRET', value: "${GH_CLIENT_SECRET}"),
                 booleanParam(name: 'SELF_SIGNED_CERTS', value: Boolean.valueOf("${SELF_SIGNED_CERTS}")),
@@ -192,7 +193,7 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             parameters = [
                 string(name: 'REPOSITORY', value: "${TEST_SUITES_REPOSITORY}"),
                 string(name: 'BRANCH', value: "${TEST_SUITES_BRANCH}"),
-                string(name: 'CLUSTER_URL', value: "${CLUSTER_URL}"),
+                string(name: 'CLUSTER_URL', value: "https://${YOURCITY}"),
                 string(name: 'ADMIN_USERNAME', value: "${OC_USER}"),
                 string(name: 'ADMIN_PASSWORD', value: "${OC_PASSWORD}"),
             ]
@@ -202,7 +203,7 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             }
 
             if (testPipeline == 'browser-based-testsuite-pipeline') {
-                parameters.add(string(name: 'WEBAPP_URL', value: "https://tutorial-web-app-webapp.apps.${CLUSTER_URI}"))
+                parameters.add(string(name: 'WEBAPP_URL', value: "https://tutorial-web-app-webapp.apps.${YOURCITY}"))
                 parameters.add(string(name: 'EVALS_PASSWORD', value: 'Password1'))
             }
 

--- a/jobs/integr8ly/poc-testing-nightly-trigger.yaml
+++ b/jobs/integr8ly/poc-testing-nightly-trigger.yaml
@@ -21,7 +21,7 @@
             INSTALLATION_BRANCH=master
             TEST_SUITES_REPOSITORY=https://gitlab.cee.redhat.com/integreatly-qe/integreatly-qe.git
             TEST_SUITES_BRANCH=master
-            CLUSTER_URL=https://integreatly-qe.opentry.me
+            YOURCITY=integreatly-qe.opentry.me
             MASTER_URLS=ec2-34-254-96-122.eu-west-1.compute.amazonaws.com,ec2-52-212-118-30.eu-west-1.compute.amazonaws.com,ec2-63-35-216-72.eu-west-1.compute.amazonaws.com
             ANSIBLE_USER=root
             OC_USER=integreatly
@@ -40,7 +40,7 @@
                         string(name: 'INSTALLATION_BRANCH', value: "${INSTALLATION_BRANCH}"),
                         string(name: 'TEST_SUITES_REPOSITORY', value: "${TEST_SUITES_REPOSITORY}"),
                         string(name: 'TEST_SUITES_BRANCH', value: "${TEST_SUITES_BRANCH}"),
-                        string(name: 'CLUSTER_URL', value: "${CLUSTER_URL}"),
+                        string(name: 'YOURCITY', value: "${YOURCITY}"),
                         string(name: 'MASTER_URLS', value: "${MASTER_URLS}"),
                         string(name: 'ANSIBLE_USER', value: "${ANSIBLE_USER}"),
                         string(name: 'OC_USER', value: "${OC_USER}"),


### PR DESCRIPTION
## What
changed cluster_url param in poc nightly trigger to yourcity. 

The poc-testing-nightly-trigger job, which is triggering poc-testing-executor is running here: https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Nightly/job/poc-testing-nightly-trigger/66/console
