### PR TITLE
add pipeline for testing integreatly on poc clusters

### DIFF
--- a/jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-test.yaml
+++ b/jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-test.yaml
@@ -1,0 +1,27 @@
+---
+- job:
+    name: openshift-cluster-integreatly-test
+    display-name: 'Openshift Cluster Integreatly Test'
+    project-type: pipeline
+    parameters:
+      - string:
+          name: 'installerGitUrl'
+          default: 'https://github.com/integr8ly/installation.git'
+          description: '[REQUIRED] Integreatly installer Git URL'
+      - string:
+          name: 'installerGitBranch'
+          default: ''
+          description: '[REQUIRED] The name of the git branch to be used for installing Integreatly'
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
+    pipeline-scm:
+      script-path: jobs/openshift/cluster/integreatly/test/Jenkinsfile
+      scm:
+        - git:
+            branches:
+              - 'master'
+            url: 'https://github.com/integr8ly/ci-cd.git'
+            skip-tag: true
+            wipe-workspace: false

--- a/jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-test.yaml
+++ b/jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-test.yaml
@@ -10,7 +10,7 @@
           description: '[REQUIRED] Integreatly installer Git URL'
       - string:
           name: 'installerGitBranch'
-          default: ''
+          default: 'master'
           description: '[REQUIRED] The name of the git branch to be used for installing Integreatly'
       - bool:
           name: 'dryRun'

--- a/jobs/openshift/cluster/integreatly/test/Jenkinsfile
+++ b/jobs/openshift/cluster/integreatly/test/Jenkinsfile
@@ -1,5 +1,3 @@
-#!groovy
-
 def testOptions = [:]
 
 def verifyParameters(testOptions) {
@@ -17,75 +15,110 @@ def verifyParameters(testOptions) {
   }
 }
 
-def buildJob(jobName, jobParams) {
-  build job: jobName, parameters: jobParams
-}
-
-stage('Verify Parameters') {
-  testOptions.awsRegion = 'eu-west-2'
-  testOptions.awsAccountName = 'fheng.AWS'
-  testOptions.clusterName = params.installerGitBranch
-  testOptions.domainName = 'skunkhenry.com'
-  testOptions.gitUrl = params.installerGitUrl
-  testOptions.gitBranch = params.installerGitBranch
-  testOptions.openshiftMasterUrl = "https://${params.installerGitBranch}.${testOptions.domainName}"
-  verifyParameters(testOptions)
-}
-
-node('cirhos_rhel7') {
-  cleanWs()
-  stage('Create Cluster') {
-    println "[INFO] Creating ${testOptions.clusterName} cluster"
-    def jobName = 'openshift-cluster-create'
-    def jobParams = [
-      [$class: 'StringParameterValue', name: 'clusterName', value: testOptions.clusterName],
-      [$class: 'StringParameterValue', name: 'awsRegion', value: testOptions.awsRegion],
-      [$class: 'StringParameterValue', name: 'awsAccountName', value: testOptions.awsAccountName],
-      [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
-    ]
-    buildJob(jobName, jobParams)
+pipeline {
+  agent {
+    node {
+      label 'cirhos_rhel7'
+    }
   }
 
-  stage('Install Integreatly') {
-    println "[INFO] Installing Integreatly in ${testOptions.clusterName} cluster"
-    def jobName = 'openshift-cluster-integreatly-install'
-    def jobParams = [
-      [$class: 'StringParameterValue', name: 'clusterName', value: testOptions.clusterName],
-      [$class: 'StringParameterValue', name: 'openshiftMasterUrl', value: testOptions.openshiftMasterUrl],
-      [$class: 'StringParameterValue', name: 'installerGitUrl', value: testOptions.gitUrl],
-      [$class: 'StringParameterValue', name: 'installerGitBranch', value: testOptions.gitBranch],
-      [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
-    ]
-    buildJob(jobName, jobParams)
+  parameters {
+    string(defaultValue: 'https://github.com/integr8ly/installation.git', description: '[REQUIRED] Integreatly installer Git URL', name: 'installerGitUrl')
+    string(defaultValue: 'master', description: '[REQUIRED] The name of the git branch to be used for installing Integreatly', name: 'installerGitBranch')
+    booleanParam(defaultValue: false, description: '[OPTIONAL][Test] Dry run only, only prints what it would do!', name: 'dryRun')
   }
 
-  stage('Test Integreatly') {
-    println "[INFO] Testing Integreatly"
+  stages {
+    stage('Verify Parameters') {
+      steps {
+        script {
+          testOptions.awsAccountName = 'fheng.AWS'
+          testOptions.awsRegion = 'eu-west-2'
+          testOptions.clusterName = params.installerGitBranch
+          testOptions.domainName = 'skunkhenry.com'
+          testOptions.gitUrl = params.installerGitUrl
+          testOptions.gitBranch = params.installerGitBranch
+          testOptions.openshiftMasterUrl = "https://${params.installerGitBranch}.${testOptions.domainName}"
+          verifyParameters(testOptions)
+        }
+      }
+    }
+
+    stage('Cluster Create') {
+      steps {
+        echo "[INFO] Creating ${testOptions.clusterName} cluster"
+        script {
+          def jobName = 'openshift-cluster-create'
+          def jobParams = [
+            [$class: 'StringParameterValue', name: 'clusterName', value: testOptions.clusterName],
+            [$class: 'StringParameterValue', name: 'awsRegion', value: testOptions.awsRegion],
+            [$class: 'StringParameterValue', name: 'awsAccountName', value: testOptions.awsAccountName],
+            [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
+          ]
+          build job: jobName, parameters: jobParams
+        }
+      }
+    }
+
+    stage('Install Integreatly') {
+      steps {
+        echo "[INFO] Installing Integreatly in ${testOptions.clusterName} cluster"
+        script {
+          jobName = 'openshift-cluster-integreatly-install'
+          jobParams = [
+            [$class: 'StringParameterValue', name: 'clusterName', value: testOptions.clusterName],
+            [$class: 'StringParameterValue', name: 'openshiftMasterUrl', value: testOptions.openshiftMasterUrl],
+            [$class: 'StringParameterValue', name: 'installerGitUrl', value: testOptions.gitUrl],
+            [$class: 'StringParameterValue', name: 'installerGitBranch', value: testOptions.gitBranch],
+            [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
+          ]
+          build job: jobName, parameters: jobParams
+        }
+      }
+    }
+
+    stage('Test Integreatly') {
+      steps {
+        echo "[INFO] Running Tests on Integreatly"
+      }
+    }
+
+    stage('Uninstall Integreatly') {
+      steps {
+        echo "[INFO] Uninstalling Integreatly from ${testOptions.clusterName}"
+        script {
+          jobName = 'openshift-cluster-integreatly-uninstall'
+          jobParams = [
+            [$class: 'StringParameterValue', name: 'clusterName', value: testOptions.clusterName],
+            [$class: 'StringParameterValue', name: 'openshiftMasterUrl', value: testOptions.openshiftMasterUrl],
+            [$class: 'StringParameterValue', name: 'uninstallerGitUrl', value: testOptions.gitUrl],
+            [$class: 'StringParameterValue', name: 'uninstallerGitBranch', value: testOptions.gitBranch],
+            [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
+          ]
+          build job: jobName, parameters: jobParams
+        }
+      }
+    }
   }
 
-  stage('Uninstall Integreatly') {
-    println "[INFO] Uninstalling Integreatly from ${testOptions.clusterName}"
-    def jobName = 'openshift-cluster-integreatly-uninstall'
-    def jobParams = [
-      [$class: 'StringParameterValue', name: 'clusterName', value: testOptions.clusterName],
-      [$class: 'StringParameterValue', name: 'openshiftMasterUrl', value: testOptions.openshiftMasterUrl],
-      [$class: 'StringParameterValue', name: 'uninstallerGitUrl', value: testOptions.gitUrl],
-      [$class: 'StringParameterValue', name: 'uninstallerGitBranch', value: testOptions.gitBranch],
-      [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
-    ]
-    buildJob(jobName, jobParams)
-  }
-
-  stage('Deprovision Cluster') {
-    println "[INFO] Deprovision ${testOptions.clusterName} cluster"
-    def jobName = 'openshift-cluster-deprovision'
-    def jobParams = [
-      [$class: 'StringParameterValue', name: 'clusterName', value: testOptions.clusterName],
-      [$class: 'StringParameterValue', name: 'awsRegion', value: testOptions.awsRegion],
-      [$class: 'StringParameterValue', name: 'awsAccountName', value: testOptions.awsAccountName],
-      [$class: 'StringParameterValue', name: 'clusterDomainName', value: testOptions.domainName],
-      [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
-    ]
-    buildJob(jobName, jobParams)
+  post {
+    always {
+      echo "[INFO] Deprovision ${testOptions.clusterName} cluster"
+      script {
+        if (testOptions.clusterName) {
+          jobName = 'openshift-cluster-deprovision'
+          jobParams = [
+            [$class: 'StringParameterValue', name: 'clusterName', value: testOptions.clusterName],
+            [$class: 'StringParameterValue', name: 'awsRegion', value: testOptions.awsRegion],
+            [$class: 'StringParameterValue', name: 'awsAccountName', value: testOptions.awsAccountName],
+            [$class: 'StringParameterValue', name: 'clusterDomainName', value: testOptions.domainName],
+            [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
+          ]
+          build job: jobName, parameters: jobParams
+        } else {
+          println "[INFO] Cluster name not available, skipping deprovision"
+        }
+      }
+    }
   }
 }

--- a/jobs/openshift/cluster/integreatly/test/Jenkinsfile
+++ b/jobs/openshift/cluster/integreatly/test/Jenkinsfile
@@ -6,7 +6,7 @@ def verifyParameters(testOptions) {
   if (!testOptions.gitUrl || !testOptions.gitBranch) {
     def userInput = input message: 'Integreatly Test Options', parameters: [
       string(defaultValue: (testOptions.gitUrl ?: 'https://github.com/integr8ly/installation.git'), description: 'Integreatly installer Git URL', name: 'installerGitUrl'),
-      string(defaultValue: (testOptions.gitBranch ?: ''), description: 'Integreatly Git Branch', name: 'installerGitBranch'),
+      string(defaultValue: (testOptions.gitBranch ?: 'master'), description: 'Integreatly Git Branch', name: 'installerGitBranch'),
     ]
 
     testOptions.gitUrl = userInput.installerGitUrl
@@ -22,8 +22,6 @@ def buildJob(jobName, jobParams) {
 }
 
 stage('Verify Parameters') {
-  testOptions.adminUsername = 'integreatly'
-  testOptions.adminPassword = 'Password1'
   testOptions.awsRegion = 'eu-west-2'
   testOptions.awsAccountName = 'fheng.AWS'
   testOptions.clusterName = params.installerGitBranch
@@ -39,18 +37,10 @@ node('cirhos_rhel7') {
   stage('Create Cluster') {
     println "[INFO] Creating ${testOptions.clusterName} cluster"
     def jobName = 'openshift-cluster-create'
-    def instanceType = 'm4.xlarge'
-    def instanceGroupSize = '3'
     def jobParams = [
       [$class: 'StringParameterValue', name: 'clusterName', value: testOptions.clusterName],
       [$class: 'StringParameterValue', name: 'awsRegion', value: testOptions.awsRegion],
       [$class: 'StringParameterValue', name: 'awsAccountName', value: testOptions.awsAccountName],
-      [$class: 'StringParameterValue', name: 'master_instance_type', value: instanceType],
-      [$class: 'StringParameterValue', name: 'compute_instance_type', value: instanceType],
-      [$class: 'StringParameterValue', name: 'infra_instance_type', value: instanceType],
-      [$class: 'StringParameterValue', name: 'master_group_size', value: instanceGroupSize],
-      [$class: 'StringParameterValue', name: 'compute_group_size', value: instanceGroupSize],
-      [$class: 'StringParameterValue', name: 'infra_group_size', value: instanceGroupSize],
       [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
     ]
     buildJob(jobName, jobParams)
@@ -59,17 +49,11 @@ node('cirhos_rhel7') {
   stage('Install Integreatly') {
     println "[INFO] Installing Integreatly in ${testOptions.clusterName} cluster"
     def jobName = 'openshift-cluster-integreatly-install'
-    def userCount = '50'
-    def selfSignedCerts = false
     def jobParams = [
       [$class: 'StringParameterValue', name: 'clusterName', value: testOptions.clusterName],
       [$class: 'StringParameterValue', name: 'openshiftMasterUrl', value: testOptions.openshiftMasterUrl],
-      [$class: 'StringParameterValue', name: 'clusterAdminUsername', value: testOptions.adminUsername],
-      [$class: 'StringParameterValue', name: 'clusterAdminPassword', value: testOptions.adminPassword],
       [$class: 'StringParameterValue', name: 'installerGitUrl', value: testOptions.gitUrl],
       [$class: 'StringParameterValue', name: 'installerGitBranch', value: testOptions.gitBranch],
-      [$class: 'StringParameterValue', name: 'userCount', value: userCount],
-      [$class: 'BooleanParameterValue', name: 'selfSignedCerts', value: selfSignedCerts],
       [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
     ]
     buildJob(jobName, jobParams)
@@ -85,8 +69,6 @@ node('cirhos_rhel7') {
     def jobParams = [
       [$class: 'StringParameterValue', name: 'clusterName', value: testOptions.clusterName],
       [$class: 'StringParameterValue', name: 'openshiftMasterUrl', value: testOptions.openshiftMasterUrl],
-      [$class: 'StringParameterValue', name: 'clusterAdminUsername', value: testOptions.adminUsername],
-      [$class: 'StringParameterValue', name: 'clusterAdminPassword', value: testOptions.adminPassword],
       [$class: 'StringParameterValue', name: 'uninstallerGitUrl', value: testOptions.gitUrl],
       [$class: 'StringParameterValue', name: 'uninstallerGitBranch', value: testOptions.gitBranch],
       [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]

--- a/jobs/openshift/cluster/integreatly/test/Jenkinsfile
+++ b/jobs/openshift/cluster/integreatly/test/Jenkinsfile
@@ -1,0 +1,109 @@
+#!groovy
+
+def testOptions = [:]
+
+def verifyParameters(testOptions) {
+  if (!testOptions.gitUrl || !testOptions.gitBranch) {
+    def userInput = input message: 'Integreatly Test Options', parameters: [
+      string(defaultValue: (testOptions.gitUrl ?: 'https://github.com/integr8ly/installation.git'), description: 'Integreatly installer Git URL', name: 'installerGitUrl'),
+      string(defaultValue: (testOptions.gitBranch ?: ''), description: 'Integreatly Git Branch', name: 'installerGitBranch'),
+    ]
+
+    testOptions.gitUrl = userInput.installerGitUrl
+    testOptions.gitBranch = userInput.installerGitBranch
+    testOptions.clusterName = userInput.installerGitBranch
+    testOptions.openshiftMasterUrl = "https://${userInput.installerGitBranch}.${testOptions.domainName}"
+    verifyParameters(testOptions)
+  }
+}
+
+def buildJob(jobName, jobParams) {
+  build job: jobName, parameters: jobParams
+}
+
+stage('Verify Parameters') {
+  testOptions.adminUsername = 'integreatly'
+  testOptions.adminPassword = 'Password1'
+  testOptions.awsRegion = 'eu-west-2'
+  testOptions.awsAccountName = 'fheng.AWS'
+  testOptions.clusterName = params.installerGitBranch
+  testOptions.domainName = 'skunkhenry.com'
+  testOptions.gitUrl = params.installerGitUrl
+  testOptions.gitBranch = params.installerGitBranch
+  testOptions.openshiftMasterUrl = "https://${params.installerGitBranch}.${testOptions.domainName}"
+  verifyParameters(testOptions)
+}
+
+node('cirhos_rhel7') {
+  cleanWs()
+  stage('Create Cluster') {
+    println "[INFO] Creating ${testOptions.clusterName} cluster"
+    def jobName = 'openshift-cluster-create'
+    def instanceType = 'm4.xlarge'
+    def instanceGroupSize = '3'
+    def jobParams = [
+      [$class: 'StringParameterValue', name: 'clusterName', value: testOptions.clusterName],
+      [$class: 'StringParameterValue', name: 'awsRegion', value: testOptions.awsRegion],
+      [$class: 'StringParameterValue', name: 'awsAccountName', value: testOptions.awsAccountName],
+      [$class: 'StringParameterValue', name: 'master_instance_type', value: instanceType],
+      [$class: 'StringParameterValue', name: 'compute_instance_type', value: instanceType],
+      [$class: 'StringParameterValue', name: 'infra_instance_type', value: instanceType],
+      [$class: 'StringParameterValue', name: 'master_group_size', value: instanceGroupSize],
+      [$class: 'StringParameterValue', name: 'compute_group_size', value: instanceGroupSize],
+      [$class: 'StringParameterValue', name: 'infra_group_size', value: instanceGroupSize],
+      [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
+    ]
+    buildJob(jobName, jobParams)
+  }
+
+  stage('Install Integreatly') {
+    println "[INFO] Installing Integreatly in ${testOptions.clusterName} cluster"
+    def jobName = 'openshift-cluster-integreatly-install'
+    def userCount = '50'
+    def selfSignedCerts = false
+    def jobParams = [
+      [$class: 'StringParameterValue', name: 'clusterName', value: testOptions.clusterName],
+      [$class: 'StringParameterValue', name: 'openshiftMasterUrl', value: testOptions.openshiftMasterUrl],
+      [$class: 'StringParameterValue', name: 'clusterAdminUsername', value: testOptions.adminUsername],
+      [$class: 'StringParameterValue', name: 'clusterAdminPassword', value: testOptions.adminPassword],
+      [$class: 'StringParameterValue', name: 'installerGitUrl', value: testOptions.gitUrl],
+      [$class: 'StringParameterValue', name: 'installerGitBranch', value: testOptions.gitBranch],
+      [$class: 'StringParameterValue', name: 'userCount', value: userCount],
+      [$class: 'BooleanParameterValue', name: 'selfSignedCerts', value: selfSignedCerts],
+      [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
+    ]
+    buildJob(jobName, jobParams)
+  }
+
+  stage('Test Integreatly') {
+    println "[INFO] Testing Integreatly"
+  }
+
+  stage('Uninstall Integreatly') {
+    println "[INFO] Uninstalling Integreatly from ${testOptions.clusterName}"
+    def jobName = 'openshift-cluster-integreatly-uninstall'
+    def jobParams = [
+      [$class: 'StringParameterValue', name: 'clusterName', value: testOptions.clusterName],
+      [$class: 'StringParameterValue', name: 'openshiftMasterUrl', value: testOptions.openshiftMasterUrl],
+      [$class: 'StringParameterValue', name: 'clusterAdminUsername', value: testOptions.adminUsername],
+      [$class: 'StringParameterValue', name: 'clusterAdminPassword', value: testOptions.adminPassword],
+      [$class: 'StringParameterValue', name: 'uninstallerGitUrl', value: testOptions.gitUrl],
+      [$class: 'StringParameterValue', name: 'uninstallerGitBranch', value: testOptions.gitBranch],
+      [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
+    ]
+    buildJob(jobName, jobParams)
+  }
+
+  stage('Deprovision Cluster') {
+    println "[INFO] Deprovision ${testOptions.clusterName} cluster"
+    def jobName = 'openshift-cluster-deprovision'
+    def jobParams = [
+      [$class: 'StringParameterValue', name: 'clusterName', value: testOptions.clusterName],
+      [$class: 'StringParameterValue', name: 'awsRegion', value: testOptions.awsRegion],
+      [$class: 'StringParameterValue', name: 'awsAccountName', value: testOptions.awsAccountName],
+      [$class: 'StringParameterValue', name: 'clusterDomainName', value: testOptions.domainName],
+      [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
+    ]
+    buildJob(jobName, jobParams)
+  }
+}

--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -58,6 +58,7 @@ generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/create/openshi
 generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/deprovision/openshift-cluster-deprovision.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-install.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-uninstall.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-test.yaml
 
 #Delorean Folders
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/delorean/folders.yaml


### PR DESCRIPTION
## What
Adds a pipeline for testing Integreatly on an OSD cluster. This job should include provisioning and deprovisioning a new cluster as well as installing, testing and uninstalling Integreatly.

- [x] Add an integreatly test job within `openshift/cluster/integreatly/`
- [x] Ensure job accepts the installation repo's git url and branch as parameters
- [x] Create a Jenkinsfile for this pipeline with the following stages:
  - **Create Cluster**: Should call the `openshift-cluster-create` pipeline
  - **Install Integreatly**: Should call the `openshift-cluster-integreatly-install` pipeline
  - **Test Integreatly**: An empty stage for now, this will be done as part of a separate [ticket](https://issues.jboss.org/browse/INTLY-1700)
  - **Uninstall Integreatly**: Should call the `openshift-cluster-integreatly-uninstall` pipeline
  - **Deprovision Cluster**: Should call the `openshift-cluster-deprovision` pipeline