### PR TITLE
add a test stage to run e2e tests for the suite ga branches

### DIFF
--- a/jobs/delorean/jenkinsfiles/branch/suite-ga/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/branch/suite-ga/Jenkinsfile
@@ -99,6 +99,17 @@ node {
           sh "git push origin ${suiteParams.suiteBranch} -f"
         }
       }
+
+      stage('Test Suite Branch') {
+        // Will trigger a build of the integreatly test job to run E2E tests using the suite branch provided
+        def jobName = 'openshift-cluster-integreatly-test'
+        def jobParams = [
+          [$class: 'StringParameterValue', name: 'installerGitUrl', value: suiteParams.gitUrl],
+          [$class: 'StringParameterValue', name: 'installerGitBranch', value: suiteParams.suiteBranch],
+          [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
+        ]
+        build job: jobName, parameters: jobParams
+      }
     }
   }
 }


### PR DESCRIPTION
## What
Add a test stage which triggers a build of the job `openshift-cluster-integreatly-test`. This job will run E2E tests on the suite branch provided from cluster creation to deprovision.

- [x] Add a stage to the suite-ga Jenkinsfile which triggers a build for the job `openshift-cluster-integreatly-test`

Depends on https://github.com/integr8ly/ci-cd/pull/127