### PR TITLE
Changed URL to clean-uninstall master node

### DIFF
--- a/jobs/integr8ly/psi-clean-uninstall.yaml
+++ b/jobs/integr8ly/psi-clean-uninstall.yaml
@@ -2,7 +2,7 @@
 
 - job:
     name: psi-clean-uninstall
-    description: 'Uninstalls Integreatly by using master node as Jenkins slave (preconfigured) and executing Ansible uninstallation playbook there. Small single node Openstack based OpenShift living in rhmobile tenant where Integreatly has never been installed is used.'
+    description: 'Uninstalls Integreatly by using master node as Jenkins slave (preconfigured) and executing Ansible uninstallation playbook there. Small single node OpenShift backed by PSI (Upshift) Openstack living in integreatly-qe tenant where Integreatly has never been installed is used.'
     project-type: pipeline
     sandbox: false
     parameters:
@@ -45,7 +45,7 @@
                             """
             
                             sh """
-                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\ntrepel-merrn-1@;P;D' ./evals/inventories/hosts
+                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\nclean-uninstall-merrn-1@;P;D' ./evals/inventories/hosts
                             """
                             
                             String output = readFile('./evals/inventories/hosts')


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

I created a new single node OCP 3.11 on PSI using Flexy installer and this is to update URL of the master node.

Successful Jenkins job build with this change:
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Nightly/job/psi-clean-uninstall/8/consoleFull

This was also OK:
jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/psi-clean-uninstall.yaml 
