### PR TITLE
Intly 1768 create jira product upgrade

### DIFF
--- a/jobs/delorean/3scale/ga/branch.yaml
+++ b/jobs/delorean/3scale/ga/branch.yaml
@@ -22,6 +22,10 @@
           default: 'threescale_version'
           description: '[REQUIRED] The manifest variable to be used as the current component version'
           read-only: true
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
       scm:

--- a/jobs/delorean/amq-online/ga/branch.yaml
+++ b/jobs/delorean/amq-online/ga/branch.yaml
@@ -22,6 +22,10 @@
           default: 'enmasse_version'
           description: '[REQUIRED] The manifest variable to be used as the current component version'
           read-only: true
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
       scm:

--- a/jobs/delorean/backup-container/ga/branch.yaml
+++ b/jobs/delorean/backup-container/ga/branch.yaml
@@ -22,6 +22,10 @@
           default: 'backup_version'
           description: '[REQUIRED] The manifest variable to be used as the current component version'
           read-only: true
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
       scm:

--- a/jobs/delorean/codeready/ga/branch.yaml
+++ b/jobs/delorean/codeready/ga/branch.yaml
@@ -22,6 +22,10 @@
           default: 'che_version'
           description: '[REQUIRED] The manifest variable to be used as the current component version'
           read-only: true
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
       scm:

--- a/jobs/delorean/fuse-online/ga/branch.yaml
+++ b/jobs/delorean/fuse-online/ga/branch.yaml
@@ -22,6 +22,10 @@
           default: 'fuse_online_release_tag'
           description: '[OPTIONAL] The manifest variable to be used as the current component release tag'
           read-only: true
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
       scm:

--- a/jobs/delorean/fuse/ga/branch.yaml
+++ b/jobs/delorean/fuse/ga/branch.yaml
@@ -22,6 +22,10 @@
           default: 'fuse_release_tag'
           description: '[REQUIRED] The manifest variable to be used as the current component version'
           read-only: true
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
       scm:

--- a/jobs/delorean/gitea/ga/branch.yaml
+++ b/jobs/delorean/gitea/ga/branch.yaml
@@ -17,15 +17,15 @@
           name: 'productName'
           default: 'gitea'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
-      - bool:
-          name: 'dryRun'
-          default: false
-          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
       - string:
           name: 'productVersionVar'
           default: 'gitea_version'
           description: '[REQUIRED] The manifest variable to be used as the current component product version'
           read-only: true
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
       scm:

--- a/jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
@@ -94,8 +94,8 @@ boolean prHasLabel(GHPullRequest pr, String labelName) {
     return hasLabel
 }
 
-def hasJiraUpdateIssue(credentials, product, productVersion) {
-    def query = "project = INTLY AND status = Open AND labels=product-update AND labels=${product} AND labels='${product}:${productVersion}'"
+def hasJiraIssue(credentials, product, productVersion, action) {
+    def query = "project = INTLY AND status = Open AND labels=product-${action} AND labels=${product} AND labels='${product}:${productVersion}'"
     def body = """{
         "jql": "${query}"
     }"""
@@ -112,7 +112,7 @@ def hasJiraUpdateIssue(credentials, product, productVersion) {
     return [found, key]
 }
 
-def createJiraIssue(credentials, gitUrl, product, productVersion) {
+def createJiraIssue(credentials, gitUrl, product, productVersion, action, summary) {
     def body = """{
         "fields": {
             "project": {
@@ -120,10 +120,10 @@ def createJiraIssue(credentials, gitUrl, product, productVersion) {
                 "key": "INTLY",
                 "name": "Integreatly"
             },
-            "summary": "Update ${product} to ${productVersion}",
+            "summary": "${summary}",
             "description": "${gitUrl}",
             "labels": [
-                "product-update",
+                "product-${action}",
                 "${product}",
                 "${product}:${productVersion}"
             ],
@@ -138,7 +138,7 @@ def createJiraIssue(credentials, gitUrl, product, productVersion) {
         }
     }"""
 
-    if (dryRun) {
+    if (params.dryRun) {
         println "Will create a JIRA issue with the following details:\n${body}"
     } else {
         def url = 'https://issues.jboss.org/rest/api/2/issue'
@@ -210,7 +210,7 @@ node {
                 String body = "Created automatically by jenkins"
 
                 if (dryRun) {
-                    println """Finds an open pull request with the base branch '${sourceBranch}'. If this does not exist, it creates a new pull request with the title '${title}' and body '${body}'."""
+                    println "Finds an open pull request with the base branch '${sourceBranch}'. If this does not exist, it creates a new pull request with the following details:\ntitle:'${title}',\nbody '${body}',\nlabels:${defaultPRLabels}"
                 } else {
                   GHPullRequest pr = ghFindOrCreatePullRequest(gitHub.getRepository("${ghOwner}/${ghRepo}"), "${ghOwner}:${sourceBranch}", targetBranch, title, body, defaultPRLabels)
                   prUrl = pr.getHtmlUrl()
@@ -221,23 +221,46 @@ node {
         }
     }
 
-    stage('Create Jira Issue') {
+    stage('Create Product Update Jira Issue') {
         when(sourceChanges) {
-            println("Creating Jira Issue for ${productName}:${productVersion}")
-            def (found, key) = hasJiraUpdateIssue(jiraUserPass, productName, productVersion)
+            println("Creating Product Update Jira Issue for ${productName}:${productVersion}")
+            def action = 'update'
+            def (found, key) = hasJiraIssue(jiraUserPass, productName, productVersion, action)
             if (!found) {
-                createJiraIssue(jiraUserPass, prUrl, productName, productVersion)
+                def summary = "Update ${productName} to ${productVersion}"
+                createJiraIssue(jiraUserPass, prUrl, productName, productVersion, action, summary)
             } else {
                 println "[INFO] Issue already open for ${productName}: https://issues.jboss.org/browse/${key}"
             }
         }
     }
 
+    stage('Create Product Upgrade Jira Issue') {
+      when(sourceChanges) {
+          dir('installation') {
+              checkoutGitRepo(installationGitUrl, targetBranch, githubSSHCredentialsID)
+              currentProductVersion = getProductVersion(productVersionVar)
+          }
+
+          if(currentProductVersion != productVersion) {
+              println("Creating Product Upgrade Jira Issue for ${productName} from ${currentProductVersion} to ${productVersion}")
+              def action = 'upgrade'
+              def (found, key) = hasJiraIssue(jiraUserPass, productName, productVersion, action)
+              if (!found) {
+                  def summary = "Add upgrade sop or playbook for ${productName} ${currentProductVersion} to ${productVersion}"
+                  createJiraIssue(jiraUserPass, prUrl, productName, productVersion, action, summary)
+              } else {
+                  println "[INFO] Issue already open for ${productName}: https://issues.jboss.org/browse/${key}"
+              }
+          }
+      }
+    }
+
     stage('Integration Tests') {
-        if (dryRun) {
-          println "Will run integration tests via 'openshift-cluster-integreatly-test' job with the following parameters and update the pull request status according to the job's status:\ninstallationGitUrl:${installationGitUrl},\nsourceBranch: ${sourceBranch},\ndryRun: ${dryRun}."
-        } else {
-            when(sourceChanges && runIntegrationTests) {
+        when(sourceChanges && runIntegrationTests) {
+            if (dryRun) {
+              println "Will run integration tests via 'openshift-cluster-integreatly-test' job with the following parameters and update the pull request status according to the job's status:\ninstallationGitUrl:${installationGitUrl},\nsourceBranch: ${sourceBranch},\ndryRun: ${dryRun}."
+            } else {
                 withCredentials([usernamePassword(
                         credentialsId: githubUserPassCredentialsID,
                         passwordVariable: 'GITHUB_PASSWORD',

--- a/jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
@@ -137,10 +137,15 @@ def createJiraIssue(credentials, gitUrl, product, productVersion) {
             "customfield_12310220": "${gitUrl}"
         }
     }"""
-    def url = 'https://issues.jboss.org/rest/api/2/issue'
-    def res = httpRequest authentication: credentials, consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'POST', requestBody: body, responseHandle: 'NONE', timeout: 60, url: url, validResponseCodes: '201'
-    def data = readJSON text: "${res.content}"
-    println "[INFO] Issue created: https://issues.jboss.org/browse/${data.key}"
+
+    if (dryRun) {
+        println "Will create a JIRA issue with the following details:\n${body}"
+    } else {
+        def url = 'https://issues.jboss.org/rest/api/2/issue'
+        def res = httpRequest authentication: credentials, consoleLogResponseBody: true, contentType: 'APPLICATION_JSON', httpMode: 'POST', requestBody: body, responseHandle: 'NONE', timeout: 60, url: url, validResponseCodes: '201'
+        def data = readJSON text: "${res.content}"
+        println "[INFO] Issue created: https://issues.jboss.org/browse/${data.key}"
+    }
 }
 
 def getProductVersion(yamlVar) {
@@ -203,10 +208,15 @@ node {
                         .build()
                 String title = "[WIP] ${productName} update"
                 String body = "Created automatically by jenkins"
-                GHPullRequest pr = ghFindOrCreatePullRequest(gitHub.getRepository("${ghOwner}/${ghRepo}"), "${ghOwner}:${sourceBranch}", targetBranch, title, body, defaultPRLabels)
-                prUrl = pr.getHtmlUrl()
-                runIntegrationTests = prHasLabel(pr, integrationTestsGHLabel)
-                println "Component Update PR = ${prUrl}, runIntegrationTests = ${runIntegrationTests}"
+
+                if (dryRun) {
+                    println """Finds an open pull request with the base branch '${sourceBranch}'. If this does not exist, it creates a new pull request with the title '${title}' and body '${body}'."""
+                } else {
+                  GHPullRequest pr = ghFindOrCreatePullRequest(gitHub.getRepository("${ghOwner}/${ghRepo}"), "${ghOwner}:${sourceBranch}", targetBranch, title, body, defaultPRLabels)
+                  prUrl = pr.getHtmlUrl()
+                  runIntegrationTests = prHasLabel(pr, integrationTestsGHLabel)
+                  println "Component Update PR = ${prUrl}, runIntegrationTests = ${runIntegrationTests}"
+                }
             }
         }
     }
@@ -224,25 +234,10 @@ node {
     }
 
     stage('Integration Tests') {
-        when(sourceChanges && runIntegrationTests) {
-            withCredentials([usernamePassword(
-                    credentialsId: githubUserPassCredentialsID,
-                    passwordVariable: 'GITHUB_PASSWORD',
-                    usernameVariable: 'GITHUB_USERNAME')]) {
-                final GitHub gitHub = new GitHubBuilder()
-                        .withOAuthToken(env.GITHUB_PASSWORD, env.GITHUB_USERNAME)
-                        .build()
-                ghUpdatePrCommitStatus(gitHub, prUrl, GHCommitState.PENDING, env.BUILD_URL, 'Pending', ghCommitStatusContext)
-            }
-            try {
-                def jobName = 'openshift-cluster-integreatly-test'
-                def jobParams = [
-                        [$class: 'StringParameterValue', name: 'installationGitUrl', value: installationGitUrl],
-                        [$class: 'StringParameterValue', name: 'installationGitBranch', value: sourceBranch],
-                        [$class: 'BooleanParameterValue', name: 'dryRun', value: dryRun]
-                ]
-                build job: jobName, parameters: jobParams
-            } catch (Exception e) {
+        if (dryRun) {
+          println "Will run integration tests via 'openshift-cluster-integreatly-test' job with the following parameters and update the pull request status according to the job's status:\ninstallationGitUrl:${installationGitUrl},\nsourceBranch: ${sourceBranch},\ndryRun: ${dryRun}."
+        } else {
+            when(sourceChanges && runIntegrationTests) {
                 withCredentials([usernamePassword(
                         credentialsId: githubUserPassCredentialsID,
                         passwordVariable: 'GITHUB_PASSWORD',
@@ -250,18 +245,37 @@ node {
                     final GitHub gitHub = new GitHubBuilder()
                             .withOAuthToken(env.GITHUB_PASSWORD, env.GITHUB_USERNAME)
                             .build()
-                    ghUpdatePrCommitStatus(gitHub, prUrl, GHCommitState.FAILURE, env.BUILD_URL, 'Failure', ghCommitStatusContext)
-                    error "Integration test failures, ${installationGitUrl}, ${sourceBranch}, ${e}"
+                    ghUpdatePrCommitStatus(gitHub, prUrl, GHCommitState.PENDING, env.BUILD_URL, 'Pending', ghCommitStatusContext)
                 }
-            }
-            withCredentials([usernamePassword(
-                    credentialsId: githubUserPassCredentialsID,
-                    passwordVariable: 'GITHUB_PASSWORD',
-                    usernameVariable: 'GITHUB_USERNAME')]) {
-                final GitHub gitHub = new GitHubBuilder()
-                        .withOAuthToken(env.GITHUB_PASSWORD, env.GITHUB_USERNAME)
-                        .build()
-                ghUpdatePrCommitStatus(gitHub, prUrl, GHCommitState.SUCCESS, env.BUILD_URL, 'Success', ghCommitStatusContext)
+                try {
+                    def jobName = 'openshift-cluster-integreatly-test'
+                    def jobParams = [
+                            [$class: 'StringParameterValue', name: 'installationGitUrl', value: installationGitUrl],
+                            [$class: 'StringParameterValue', name: 'installationGitBranch', value: sourceBranch],
+                            [$class: 'BooleanParameterValue', name: 'dryRun', value: dryRun]
+                    ]
+                    build job: jobName, parameters: jobParams
+                } catch (Exception e) {
+                    withCredentials([usernamePassword(
+                            credentialsId: githubUserPassCredentialsID,
+                            passwordVariable: 'GITHUB_PASSWORD',
+                            usernameVariable: 'GITHUB_USERNAME')]) {
+                        final GitHub gitHub = new GitHubBuilder()
+                                .withOAuthToken(env.GITHUB_PASSWORD, env.GITHUB_USERNAME)
+                                .build()
+                        ghUpdatePrCommitStatus(gitHub, prUrl, GHCommitState.FAILURE, env.BUILD_URL, 'Failure', ghCommitStatusContext)
+                        error "Integration test failures, ${installationGitUrl}, ${sourceBranch}, ${e}"
+                    }
+                }
+                withCredentials([usernamePassword(
+                        credentialsId: githubUserPassCredentialsID,
+                        passwordVariable: 'GITHUB_PASSWORD',
+                        usernameVariable: 'GITHUB_USERNAME')]) {
+                  final GitHub gitHub = new GitHubBuilder()
+                          .withOAuthToken(env.GITHUB_PASSWORD, env.GITHUB_USERNAME)
+                          .build()
+                  ghUpdatePrCommitStatus(gitHub, prUrl, GHCommitState.SUCCESS, env.BUILD_URL, 'Success', ghCommitStatusContext)
+                }
             }
         }
     }

--- a/jobs/delorean/keycloak/ga/branch.yaml
+++ b/jobs/delorean/keycloak/ga/branch.yaml
@@ -17,11 +17,15 @@
           name: 'productName'
           default: 'rhsso'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
-       string:
+      - string:
           name: 'productVersionVar'
           default: 'SSO_VERSION'
           description: '[OPTIONAL] Identifier to be used to retrieve the product version from the productVersionLocation'
           read-only: true
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
       scm:

--- a/jobs/delorean/middleware-monitoring/ga/branch.yaml
+++ b/jobs/delorean/middleware-monitoring/ga/branch.yaml
@@ -22,6 +22,10 @@
           default: 'middleware_monitoring_operator_release_tag'
           description: '[OPTIONAL] The manifest variable to be used as the current component release tag'
           read-only: true
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
       scm:

--- a/jobs/delorean/msbroker/ga/branch.yaml
+++ b/jobs/delorean/msbroker/ga/branch.yaml
@@ -22,6 +22,10 @@
           default: 'msbroker_release_tag'
           description: '[REQUIRED] The manifest variable to be used as the current component version'
           read-only: true
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
       scm:

--- a/jobs/delorean/rhsso/ga/branch.yaml
+++ b/jobs/delorean/rhsso/ga/branch.yaml
@@ -22,6 +22,10 @@
           default: 'rhsso_operator_release_tag'
           description: '[OPTIONAL] The manifest variable to be used as the current component release tag'
           read-only: true
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
       scm:

--- a/jobs/delorean/webapp/ga/branch.yaml
+++ b/jobs/delorean/webapp/ga/branch.yaml
@@ -17,11 +17,15 @@
           name: 'productName'
           default: 'webapp'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
-       string:
+      - string:
           name: 'productVersionVar'
           default: 'webapp_version'
           description: '[REQUIRED] The manifest variable to be used as the current component product version'
           read-only: true
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
       scm:


### PR DESCRIPTION
## What
- [x] Add `dryRun` params to all branch jobs
- [x] Add a stage for creating a product upgrade ticket in JIRA
    - Refactor the `hasJiraUpdateIssue` to be used for creating the product upgrade ticket
    - Refactor the `createJiraIssue` to be used for creating the product upgrade ticket

Example JIRA Tickets created by the job:
- https://issues.jboss.org/browse/INTLY-1792
- https://issues.jboss.org/browse/INTLY-1793