### PR TITLE
Added namespace prefix to webapp URL

### DIFF
--- a/jobs/integr8ly/pds-testing-executor.yaml
+++ b/jobs/integr8ly/pds-testing-executor.yaml
@@ -179,7 +179,7 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             }
 
             if (testPipeline == 'browser-based-testsuite-pipeline') {
-                parameters.add(string(name: 'WEBAPP_URL', value: "https://tutorial-web-app-webapp.apps.${YOURCITY}.openshiftworkshop.com"))
+                parameters.add(string(name: 'WEBAPP_URL', value: "https://tutorial-web-app-${NAMESPACE-PREFIX}webapp.apps.${YOURCITY}.openshiftworkshop.com"))
                 parameters.add(string(name: 'EVALS_USERNAME', value: 'evals23@example.com'))
                 parameters.add(string(name: 'EVALS_PASSWORD', value: 'Password1'))
             }

--- a/jobs/integr8ly/poc-testing-executor.yaml
+++ b/jobs/integr8ly/poc-testing-executor.yaml
@@ -211,7 +211,7 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             }
 
             if (testPipeline == 'browser-based-testsuite-pipeline') {
-                parameters.add(string(name: 'WEBAPP_URL', value: "https://tutorial-web-app-webapp.apps.${CLUSTER_HOSTNAME}"))
+                parameters.add(string(name: 'WEBAPP_URL', value: "https://tutorial-web-app-${NAMESPACE-PREFIX}webapp.apps.${CLUSTER_HOSTNAME}"))
                 parameters.add(string(name: 'EVALS_USERNAME', value: 'evals11@example.com'))
                 parameters.add(string(name: 'EVALS_PASSWORD', value: 'Password1'))
             }


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Namespace prefix also affects webapp URL. We need to make sure that poc- and pds- testing executors call the browser-based test suite (webapp URL is an input param of this test suite) accordingly.

Verification steps

Build in jenkins:
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/PDS/job/pds-testing-executor/24/consoleFull

You can see that it called the browser testsuite with correct webapp URL
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/browser-based-testsuite-pipeline/358/parameters/

I assume that there is no need to test for POC since it is the same.

