### PR TITLE
Removed create_cluster_admin param from uninstall

### DIFF
--- a/jobs/integr8ly/poc-uninstall.yaml
+++ b/jobs/integr8ly/poc-uninstall.yaml
@@ -92,7 +92,7 @@
                 stage('Execute playbook') {
                     dir('installation/evals') {
                         sh """
-                            sudo ansible-playbook -i ./inventories/hosts ./playbooks/uninstall.yml -e create_cluster_admin=false -e openshift_login=true -e openshift_username=${OC_USER} -e openshift_password=${OC_PASSWORD} -e openshift_master_public_url=${CLUSTER_URL} -e ns_prefix=${NAMESPACE_PREFIX}
+                            sudo ansible-playbook -i ./inventories/hosts ./playbooks/uninstall.yml -e openshift_login=true -e openshift_username=${OC_USER} -e openshift_password=${OC_PASSWORD} -e openshift_master_public_url=${CLUSTER_URL} -e ns_prefix=${NAMESPACE_PREFIX}
                         """
                      } // dir
                 } // stage


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

The parameter is not used for uninstall - the uninstall removes all the users here (not using this param at all, if the cluster admin user exists, it is just removed together with evals users):
https://github.com/integr8ly/installation/blob/master/roles/rhsso/tasks/remove_identityprovider.yml#L48-L59

successful poc-uninstall build with this change:
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/POC/job/poc-uninstall/73/