### PR TITLE
Added namespace prefix to w1A test

### DIFF
--- a/jobs/integr8ly/w1-test-executor.yaml
+++ b/jobs/integr8ly/w1-test-executor.yaml
@@ -16,6 +16,9 @@
       - string:
           name: CLUSTER_URL
           description: 'URL of cluster on which the W1 test will be executed.'
+      - string:
+          name: NAMESPACE_PREFIX
+          description: "Value used to prefix the names of the namespaces created during Integr8ly installation"
       - string: 
           name: ADMIN_USERNAME
           default: 'admin@example.com'
@@ -50,6 +53,7 @@
                                     string(name: 'REPOSITORY', value: "${REPOSITORY}"),
                                     string(name: 'BRANCH', value: "${BRANCH}"),
                                     string(name: 'CLUSTER_URL', value: "${CLUSTER_URL}"),
+                                    string(name: 'NAMESPACE_PREFIX', value: "${NAMESPACE_PREFIX}"),
                                     string(name: 'ADMIN_USERNAME', value: "${ADMIN_USERNAME}"),
                                     string(name: 'ADMIN_PASSWORD', value: "${ADMIN_PASSWORD}"),
                                     string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

The AMQ address creation test requires NAMESPACE_PREFIX as input param. The w1A test pipeline triggers the AMQ address creation test pipeline under the hood thus w1A test pipeline must pass this input param to AMQ address creation pipeline.
