### PR TITLE
Added namespace prefix to fuse and w1A test

### DIFF
--- a/jobs/integr8ly/fuse-test.yaml
+++ b/jobs/integr8ly/fuse-test.yaml
@@ -16,6 +16,9 @@
       - string:
           name: CLUSTER_URL
           description: 'URL of cluster on which the tests will be executed.'
+      - string:
+          name: NAMESPACE_PREFIX
+          description: "Value used to prefix the names of the namespaces created during Integr8ly installation"
       - string: 
           name: ADMIN_USERNAME
           default: 'admin@example.com'

--- a/jobs/integr8ly/w1-test-executor.yaml
+++ b/jobs/integr8ly/w1-test-executor.yaml
@@ -72,6 +72,7 @@
                                     string(name: 'REPOSITORY', value: "${REPOSITORY}"),
                                     string(name: 'BRANCH', value: "${BRANCH}"),
                                     string(name: 'CLUSTER_URL', value: "${CLUSTER_URL}"),
+                                    string(name: 'NAMESPACE_PREFIX', value: "${NAMESPACE_PREFIX}"),
                                     string(name: 'ADMIN_USERNAME', value: "${ADMIN_USERNAME}"),
                                     string(name: 'ADMIN_PASSWORD', value: "${ADMIN_PASSWORD}"),
                                     string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Added proper namespace prefix handling between wt1-test-executor and fuse-test pipelines.

jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/w1-test-executor.yaml
jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/fuse-test.yaml

Successful Jenkins build with these modifications in place:
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/w1-test-executor/26

Additional notes
This is followup change to
https://gitlab.cee.redhat.com/integreatly-qe/integreatly-qe/merge_requests/131/