### PR TITLE
Defaulting to empty NS prefix for RHPDS

### DIFF
--- a/jobs/integr8ly/pds-install.yaml
+++ b/jobs/integr8ly/pds-install.yaml
@@ -44,8 +44,8 @@
             description: "Additional parameters passed to install playbook, e.g.'-e eval_seed_users_count=0'. Can be left empty"
         - string:
             name: NAMESPACE_PREFIX
-            default: rhpds-
-            description: "This value will be prefixed to the names of the namespaces created during Integr8ly installation"
+            default: ''
+            description: "This value will be prefixed to the names of the namespaces created during Integr8ly installation. Defaulting to empty string for RHPDS"
     dsl: |
         import hudson.model.*
         import jenkins.model.*

--- a/jobs/integr8ly/pds-testing-executor.yaml
+++ b/jobs/integr8ly/pds-testing-executor.yaml
@@ -94,8 +94,8 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             description: 'Number of created users (sso-user-create test)'
         - string:
             name: NAMESPACE_PREFIX
-            default: rhpds-
-            description: "This value will be prefixed to the names of the namespaces created during Integr8ly installation"
+            default: ''
+            description: "This value will be prefixed to the names of the namespaces created during Integr8ly installation. Defaulting to empty string for RHPDS"
         - choice:
             name: TO_DO
             description: "It specifies what stages of the pipeline will be executed. 'full' means uninstall + uninstall + install + install + tests + uninstall + install"

--- a/jobs/integr8ly/pds-testing-nightly-trigger.yaml
+++ b/jobs/integr8ly/pds-testing-nightly-trigger.yaml
@@ -34,7 +34,7 @@
             TESTING_MASTER=true
             WALKTHROUGHS_VERSION=master
             NUMBER_OF_USERS=5
-            NAMESPACE_PREFIX=rhpds-
+            NAMESPACE_PREFIX=''
             TO_DO=full
     dsl: |
         timeout(180) { ansiColor('gnome-terminal') { timestamps {

--- a/jobs/integr8ly/pds-uninstall.yaml
+++ b/jobs/integr8ly/pds-uninstall.yaml
@@ -31,8 +31,8 @@
             description: "ID of SSH Credentials (private key) used for SSH-ing to bastion"
         - string:
             name: NAMESPACE_PREFIX
-            default: rhpds-
-            description: "This value will be used to define the prefix of the names of the namespaces deleted during uninstallation"
+            default: ''
+            description: "This value will be used to define the prefix of the names of the namespaces deleted during uninstallation. Defaulting to empty string for RHPDS."
     dsl: |
         import hudson.model.*
         import jenkins.model.*


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

As per discussion with eng, we only support empty namespace prefix for RHPDS thus the default values for this param were updated to an empty string

## Verification steps
jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/pds-install.yaml
jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/pds-uninstall.yaml
jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/pds-testing-executor.yaml
jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/pds-testing-nightly-trigger.yaml

