### PR TITLE
INTLY-1853 workaround - not patching monitoring operator

### DIFF
--- a/jobs/integr8ly/pds-install.yaml
+++ b/jobs/integr8ly/pds-install.yaml
@@ -59,7 +59,7 @@
                                   "gitea_operator_release_tag",
                                   "webapp_version",
                                   "webapp_operator_release_tag",
-                                  "middleware_monitoring_operator_release_tag",
+                                  //"middleware_monitoring_operator_release_tag",
                                   "backup_version"]
         String MASTER_URL = "master1.${YOURCITY}.internal"
         String BASTION_URL = "bastion.${YOURCITY}.openshiftworkshop.com"    

--- a/jobs/integr8ly/poc-install.yaml
+++ b/jobs/integr8ly/poc-install.yaml
@@ -56,7 +56,7 @@
                                   "gitea_operator_release_tag",
                                   "webapp_version",
                                   "webapp_operator_release_tag",
-                                  "middleware_monitoring_operator_release_tag",
+                                  //"middleware_monitoring_operator_release_tag",
                                   "backup_version"]
 
         timeout(60) { ansiColor('gnome-terminal') { timestamps {


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Due to https://issues.jboss.org/browse/INTLY-1853 we need to disable patching the monitoring operator.
