### PR TITLE
Removed INTLY-1853 workaround

### DIFF
--- a/jobs/integr8ly/pds-install.yaml
+++ b/jobs/integr8ly/pds-install.yaml
@@ -59,7 +59,7 @@
                                   "gitea_operator_release_tag",
                                   "webapp_version",
                                   "webapp_operator_release_tag",
-                                  //"middleware_monitoring_operator_release_tag",
+                                  "middleware_monitoring_operator_release_tag",
                                   "backup_version"]
         String MASTER_URL = "master1.${YOURCITY}.internal"
         String BASTION_URL = "bastion.${YOURCITY}.openshiftworkshop.com"    

--- a/jobs/integr8ly/poc-install.yaml
+++ b/jobs/integr8ly/poc-install.yaml
@@ -56,7 +56,7 @@
                                   "gitea_operator_release_tag",
                                   "webapp_version",
                                   "webapp_operator_release_tag",
-                                  //"middleware_monitoring_operator_release_tag",
+                                  "middleware_monitoring_operator_release_tag",
                                   "backup_version"]
 
         timeout(60) { ansiColor('gnome-terminal') { timestamps {


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Removal of INTLY-1853 workaround since the issue was fixed.


Jenkins build with no workaround passes now:
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/poc-install/77/
