### PR TITLE
Update amq online discovery job to use tag release fetch method.

### DIFF
--- a/jobs/delorean/amq-online/ga/discovery.yaml
+++ b/jobs/delorean/amq-online/ga/discovery.yaml
@@ -27,6 +27,15 @@
           default: 'amq-online'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
+      - string:
+          name: 'releaseFetchMethod'
+          default: 'tag'
+          description: '[REQUIRED] Method to fetch latest release which can either be by tag or by release'
+          read-only: true
+      - string:
+          name: 'gaReleaseTagRef'
+          default: 'GA'
+          description: '[REQUIRED] Reference used to filter GA releases from the repository tags'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:


### PR DESCRIPTION
## What

Update amq online discovery job to use tag release fetch method. Latest release din;t create a GH release, so probably best to just rely on the tag method of finding new GA releases see https://github.com/jboss-container-images/amq-online-images/tags
