### PR TITLE
enable concurrent jobs for tower

### DIFF
--- a/jobs/openshift/cluster/create/openshift-cluster-create.yaml
+++ b/jobs/openshift/cluster/create/openshift-cluster-create.yaml
@@ -3,6 +3,7 @@
     name: openshift-cluster-create
     display-name: 'OpenShift Cluster Create'
     project-type: pipeline
+    concurrent: true
     parameters:
       - string:
           name: 'clusterName'

--- a/jobs/openshift/cluster/deprovision/openshift-cluster-deprovision.yaml
+++ b/jobs/openshift/cluster/deprovision/openshift-cluster-deprovision.yaml
@@ -3,6 +3,7 @@
     name: openshift-cluster-deprovision
     display-name: 'OpenShift Cluster Deprovision'
     project-type: pipeline
+    concurrent: true
     parameters:
       - string:
           name: 'clusterName'

--- a/jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-install.yaml
+++ b/jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-install.yaml
@@ -3,6 +3,7 @@
     name: openshift-cluster-integreatly-install
     display-name: 'Openshift Cluster Integreatly Install'
     project-type: pipeline
+    concurrent: true
     parameters:
       - string:
           name: 'clusterName'

--- a/jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-test.yaml
+++ b/jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-test.yaml
@@ -3,6 +3,7 @@
     name: openshift-cluster-integreatly-test
     display-name: 'Openshift Cluster Integreatly Test'
     project-type: pipeline
+    concurrent: true
     parameters:
       - string:
           name: 'installationGitUrl'

--- a/jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-uninstall.yaml
+++ b/jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-uninstall.yaml
@@ -3,6 +3,7 @@
     name: openshift-cluster-integreatly-uninstall
     display-name: 'Openshift Cluster Integreatly Uninstall'
     project-type: pipeline
+    concurrent: true
     parameters:
       - string:
           name: 'clusterName'


### PR DESCRIPTION
## What
Set `concurrent: true` in the Openshift tower jobs on Jenkins to enable concurrent builds so that builds triggered with `dryRun` won't get blocked.