### PR TITLE
remove default ns prefix param from pds

### DIFF
--- a/jobs/integr8ly/installation-smoke-tests.yaml
+++ b/jobs/integr8ly/installation-smoke-tests.yaml
@@ -31,11 +31,7 @@
       - bool:
           name: TESTING_MASTER
           default: true
-          description: 'Indicates whether to check master tags or compare versions from manifest file.'   
-      - string:
-          name: WALKTHROUGHS_VERSION
-          default: ''
-          description: 'Provide walkthroughs release version. Empty value means the master version is expected.'
+          description: 'Indicates whether to check master tags or compare versions from manifest file.'
       - string:
           name: NAMESPACE_PREFIX
           description: "Value used to prefix the names of the namespaces created during Integr8ly installation"

--- a/jobs/integr8ly/pds-install.yaml
+++ b/jobs/integr8ly/pds-install.yaml
@@ -48,7 +48,6 @@
             description: "Indicates whether the components should be patched to master during installation"
         - string:
             name: NAMESPACE_PREFIX
-            default: ''
             description: "This value will be prefixed to the names of the namespaces created during Integr8ly installation. Defaulting to empty string for RHPDS"
     dsl: |
         import hudson.model.*

--- a/jobs/integr8ly/pds-testing-executor.yaml
+++ b/jobs/integr8ly/pds-testing-executor.yaml
@@ -83,11 +83,7 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
         - bool:
             name: TESTING_MASTER
             default: true
-            description: 'Indicates whether to check master tags or compare versions from manifest file (smoke tests)'   
-        - string:
-            name: WALKTHROUGHS_VERSION
-            default: ''
-            description: 'Provide walkthroughs release version. Empty value means the master version is expected (smoke tests)'
+            description: 'Indicates whether to check master tags or compare versions from manifest file (smoke tests)'
         - string:
             name: NUMBER_OF_USERS
             default: "5"
@@ -224,7 +220,6 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                 booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("${CLEAN_RESOURCES}")),
                 string(name: 'MANIFEST_VERSION', value: "${MANIFEST_VERSION}"),
                 booleanParam(name: 'TESTING_MASTER', value: Boolean.valueOf("${TESTING_MASTER}")),
-                string(name: 'WALKTHROUGHS_VERSION', value: "${WALKTHROUGHS_VERSION}"),
                 string(name: 'SSO_URL', value: "https://sso-${NAMESPACE_PREFIX}sso.apps.${YOURCITY}.openshiftworkshop.com"),
                 string(name: 'NUMBER_OF_USERS', value: "${NUMBER_OF_USERS}")
             ]

--- a/jobs/integr8ly/pds-testing-executor.yaml
+++ b/jobs/integr8ly/pds-testing-executor.yaml
@@ -98,7 +98,6 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             description: "Indicates whether the components should be patched to master during installation"
         - string:
             name: NAMESPACE_PREFIX
-            default: ''
             description: "This value will be prefixed to the names of the namespaces created during Integr8ly installation. Defaulting to empty string for RHPDS"
         - choice:
             name: TO_DO

--- a/jobs/integr8ly/pds-testing-nightly-no-patch-trigger.yaml
+++ b/jobs/integr8ly/pds-testing-nightly-no-patch-trigger.yaml
@@ -32,7 +32,6 @@
             CLEAN_RESOURCES=true
             MANIFEST_VERSION=master
             TESTING_MASTER=false
-            WALKTHROUGHS_VERSION=master
             NUMBER_OF_USERS=5
             PATCH_TO_MASTER=false
             TO_DO=full
@@ -60,7 +59,6 @@
                         booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("${CLEAN_RESOURCES}")),
                         string(name: 'MANIFEST_VERSION', value: "${MANIFEST_VERSION}"),
                         booleanParam(name: 'TESTING_MASTER', value: Boolean.valueOf("${TESTING_MASTER}")),
-                        string(name: 'WALKTHROUGHS_VERSION', value: "${WALKTHROUGHS_VERSION}"),
                         string(name: 'NUMBER_OF_USERS', value: "${NUMBER_OF_USERS}"),
                         booleanParam(name: 'PATCH_TO_MASTER', value: Boolean.valueOf("${PATCH_TO_MASTER}")),
                         string(name: 'TO_DO', value: "${TO_DO}")

--- a/jobs/integr8ly/pds-testing-nightly-no-patch-trigger.yaml
+++ b/jobs/integr8ly/pds-testing-nightly-no-patch-trigger.yaml
@@ -35,7 +35,6 @@
             WALKTHROUGHS_VERSION=master
             NUMBER_OF_USERS=5
             PATCH_TO_MASTER=false
-            NAMESPACE_PREFIX=''
             TO_DO=full
     dsl: |
         timeout(210) { ansiColor('gnome-terminal') { timestamps {
@@ -64,7 +63,6 @@
                         string(name: 'WALKTHROUGHS_VERSION', value: "${WALKTHROUGHS_VERSION}"),
                         string(name: 'NUMBER_OF_USERS', value: "${NUMBER_OF_USERS}"),
                         booleanParam(name: 'PATCH_TO_MASTER', value: Boolean.valueOf("${PATCH_TO_MASTER}")),
-                        string(name: 'NAMESPACE_PREFIX', value: "${NAMESPACE_PREFIX}"),
                         string(name: 'TO_DO', value: "${TO_DO}")
                     ]).result
 

--- a/jobs/integr8ly/pds-testing-nightly-trigger.yaml
+++ b/jobs/integr8ly/pds-testing-nightly-trigger.yaml
@@ -32,7 +32,6 @@
             CLEAN_RESOURCES=true
             MANIFEST_VERSION=master
             TESTING_MASTER=true
-            WALKTHROUGHS_VERSION=master
             NUMBER_OF_USERS=5
             PATCH_TO_MASTER=true
             TO_DO=full
@@ -60,7 +59,6 @@
                         booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("${CLEAN_RESOURCES}")),
                         string(name: 'MANIFEST_VERSION', value: "${MANIFEST_VERSION}"),
                         booleanParam(name: 'TESTING_MASTER', value: Boolean.valueOf("${TESTING_MASTER}")),
-                        string(name: 'WALKTHROUGHS_VERSION', value: "${WALKTHROUGHS_VERSION}"),
                         string(name: 'NUMBER_OF_USERS', value: "${NUMBER_OF_USERS}"),
                         booleanParam(name: 'PATCH_TO_MASTER', value: Boolean.valueOf("${PATCH_TO_MASTER}")),
                         string(name: 'TO_DO', value: "${TO_DO}")

--- a/jobs/integr8ly/pds-testing-nightly-trigger.yaml
+++ b/jobs/integr8ly/pds-testing-nightly-trigger.yaml
@@ -35,7 +35,6 @@
             WALKTHROUGHS_VERSION=master
             NUMBER_OF_USERS=5
             PATCH_TO_MASTER=true
-            NAMESPACE_PREFIX=''
             TO_DO=full
     dsl: |
         timeout(210) { ansiColor('gnome-terminal') { timestamps {
@@ -64,7 +63,6 @@
                         string(name: 'WALKTHROUGHS_VERSION', value: "${WALKTHROUGHS_VERSION}"),
                         string(name: 'NUMBER_OF_USERS', value: "${NUMBER_OF_USERS}"),
                         booleanParam(name: 'PATCH_TO_MASTER', value: Boolean.valueOf("${PATCH_TO_MASTER}")),
-                        string(name: 'NAMESPACE_PREFIX', value: "${NAMESPACE_PREFIX}"),
                         string(name: 'TO_DO', value: "${TO_DO}")
                     ]).result
 

--- a/jobs/integr8ly/pds-uninstall.yaml
+++ b/jobs/integr8ly/pds-uninstall.yaml
@@ -31,7 +31,6 @@
             description: "ID of SSH Credentials (private key) used for SSH-ing to bastion"
         - string:
             name: NAMESPACE_PREFIX
-            default: ''
             description: "This value will be used to define the prefix of the names of the namespaces deleted during uninstallation. Defaulting to empty string for RHPDS."
     dsl: |
         import hudson.model.*

--- a/jobs/integr8ly/poc-testing-executor.yaml
+++ b/jobs/integr8ly/poc-testing-executor.yaml
@@ -91,11 +91,7 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
         - bool:
             name: TESTING_MASTER
             default: true
-            description: 'Indicates whether to check master tags or compare versions from manifest file (smoke tests)'   
-        - string:
-            name: WALKTHROUGHS_VERSION
-            default: ''
-            description: 'Provide walkthroughs release version. Empty value means the master version is expected (smoke tests)'
+            description: 'Indicates whether to check master tags or compare versions from manifest file (smoke tests)'
         - string:
             name: NUMBER_OF_USERS
             default: "5"
@@ -104,6 +100,10 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             name: PATCH_TO_MASTER
             default: false
             description: "Indicates whether the components should be patched to master during installation"
+        - string:
+            name: NAMESPACE_PREFIX
+            default: openshift-
+            description: "This value will be prefixed to the names of the namespaces created during Integr8ly installation"
         - choice:
             name: TO_DO
             description: "It specifies what stages of the pipeline will be executed. 'full' means uninstall + uninstall + install + install + tests + uninstall + install"

--- a/jobs/integr8ly/poc-testing-executor.yaml
+++ b/jobs/integr8ly/poc-testing-executor.yaml
@@ -104,10 +104,6 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             name: PATCH_TO_MASTER
             default: false
             description: "Indicates whether the components should be patched to master during installation"
-        - string:
-            name: NAMESPACE_PREFIX
-            default: openshift-
-            description: "This value will be prefixed to the names of the namespaces created during Integr8ly installation"
         - choice:
             name: TO_DO
             description: "It specifies what stages of the pipeline will be executed. 'full' means uninstall + uninstall + install + install + tests + uninstall + install"
@@ -249,7 +245,6 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                 booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("${CLEAN_RESOURCES}")),
                 string(name: 'MANIFEST_VERSION', value: "${MANIFEST_VERSION}"),
                 booleanParam(name: 'TESTING_MASTER', value: Boolean.valueOf("${TESTING_MASTER}")),
-                string(name: 'WALKTHROUGHS_VERSION', value: "${WALKTHROUGHS_VERSION}"),
                 string(name: 'SSO_URL', value: "https://sso-${NAMESPACE_PREFIX}sso.apps.${CLUSTER_HOSTNAME}"),
                 string(name: 'NUMBER_OF_USERS', value: "${NUMBER_OF_USERS}")
             ]

--- a/jobs/integr8ly/poc-testing-nightly-no-patch-trigger.yaml
+++ b/jobs/integr8ly/poc-testing-nightly-no-patch-trigger.yaml
@@ -34,7 +34,6 @@
             CLEAN_RESOURCES=true
             MANIFEST_VERSION=master
             TESTING_MASTER=false
-            WALKTHROUGHS_VERSION=master
             NUMBER_OF_USERS=5
             PATCH_TO_MASTER=false
             NAMESPACE_PREFIX=openshift-
@@ -65,7 +64,6 @@
                         booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("${CLEAN_RESOURCES}")),
                         string(name: 'MANIFEST_VERSION', value: "${MANIFEST_VERSION}"),
                         booleanParam(name: 'TESTING_MASTER', value: Boolean.valueOf("${TESTING_MASTER}")),
-                        string(name: 'WALKTHROUGHS_VERSION', value: "${WALKTHROUGHS_VERSION}"),
                         string(name: 'NUMBER_OF_USERS', value: "${NUMBER_OF_USERS}"),
                         booleanParam(name: 'PATCH_TO_MASTER', value: Boolean.valueOf("${PATCH_TO_MASTER}")),
                         string(name: 'NAMESPACE_PREFIX', value: "${NAMESPACE_PREFIX}"),

--- a/jobs/integr8ly/poc-testing-nightly-trigger.yaml
+++ b/jobs/integr8ly/poc-testing-nightly-trigger.yaml
@@ -34,7 +34,6 @@
             CLEAN_RESOURCES=true
             MANIFEST_VERSION=master
             TESTING_MASTER=true
-            WALKTHROUGHS_VERSION=master
             NUMBER_OF_USERS=5
             PATCH_TO_MASTER=true
             NAMESPACE_PREFIX=openshift-
@@ -65,7 +64,6 @@
                         booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("${CLEAN_RESOURCES}")),
                         string(name: 'MANIFEST_VERSION', value: "${MANIFEST_VERSION}"),
                         booleanParam(name: 'TESTING_MASTER', value: Boolean.valueOf("${TESTING_MASTER}")),
-                        string(name: 'WALKTHROUGHS_VERSION', value: "${WALKTHROUGHS_VERSION}"),
                         string(name: 'NUMBER_OF_USERS', value: "${NUMBER_OF_USERS}"),
                         booleanParam(name: 'PATCH_TO_MASTER', value: Boolean.valueOf("${PATCH_TO_MASTER}")),
                         string(name: 'NAMESPACE_PREFIX', value: "${NAMESPACE_PREFIX}"),


### PR DESCRIPTION
## What
remove default ns prefix param from pds and abandoned param from smoke tests (`WALKTHROUGHS_VERSION `)

## Verification
Carefully check, whether all required occurrences of WALKTHROUGHS_VERSION and NAMESPACE_PREFIX were removed/ defaulted to no value (NS on PDS)