### PR TITLE
Add a pre install stage to the openshift integreatly install pipeline

### DIFF
--- a/jobs/openshift/cluster/brew/Jenkinsfile
+++ b/jobs/openshift/cluster/brew/Jenkinsfile
@@ -55,6 +55,7 @@ stage('Image Sync Options') {
 
 def githubSSHCredentialsID = 'jenkinsgithub'
 def imageSyncConfigFile = './integreatly.yml'
+def imageSyncConfigContent
 String brewContainerRegistry
 def projectsToSync
 def syncImages = false
@@ -64,21 +65,21 @@ node('cirhos_rhel7') {
     stage('Ensure Sync File Exists') {
         dir('installation') {
             gitCheckoutRepo(imageSyncOptions.installationGitUrl, imageSyncOptions.installationGitBranch, githubSSHCredentialsID, '.')
-            syncImages = fileExists imageSyncConfigFile
+            def imageSyncFileExists = fileExists imageSyncConfigFile
+            imageSyncConfigContent = readYaml file: imageSyncConfigFile
 
-            if (!syncImages) {
-                println "Image sync file '${imageSyncConfigFile}' is not available. No images to sync, skipping!"
+            if (imageSyncFileExists && imageSyncConfigContent.imageSync && imageSyncConfigContent.imageSync.projects) {
+                syncImages = true
+            } else {
+                println "No images to sync, skipping!"
             }
         }
     }
 
     stage('Get Images To Sync') {
         when(syncImages) {
-            dir('installation') {
-                def imageSyncConfigContent = readYaml file: imageSyncConfigFile
-                projectsToSync = imageSyncConfigContent.imageSync
-                brewContainerRegistry = imageSyncConfigContent.sourceRepo
-            }
+            projectsToSync = imageSyncConfigContent.imageSync.projects
+            brewContainerRegistry = imageSyncConfigContent.imageSync.sourceRepo
         }
     }
 
@@ -114,7 +115,7 @@ node('cirhos_rhel7') {
                 brewContainerRegistry = projectConfig.sourceRepo ?: brewContainerRegistry
 
                 if (!brewContainerRegistry) {
-                  error "Brew container registry was not specified"
+                    error "Brew container registry was not specified"
                 } else {
                     projectConfig.images.each {
                         def brewImageUrl = "${brewContainerRegistry}/${project}/${it}"
@@ -125,12 +126,12 @@ node('cirhos_rhel7') {
                         } else {
                             retry(3) {
                                 sh """
-                                  skopeo copy \
-                                  --dest-creds ${imageSyncOptions.clusterAdminUsername}:${imageSyncOptions.clusterAdminAuthToken} \
-                                  --dest-tls-verify=false \
-                                  --src-tls-verify=false \
-                                  docker://${brewImageUrl} \
-                                  docker://${clusterImageUrlPub}
+                                    skopeo copy \
+                                    --dest-creds ${imageSyncOptions.clusterAdminUsername}:${imageSyncOptions.clusterAdminAuthToken} \
+                                    --dest-tls-verify=false \
+                                    --src-tls-verify=false \
+                                    docker://${brewImageUrl} \
+                                    docker://${clusterImageUrlPub}
                                 """
                             }
                         }

--- a/jobs/openshift/cluster/brew/Jenkinsfile
+++ b/jobs/openshift/cluster/brew/Jenkinsfile
@@ -1,0 +1,143 @@
+#!groovy
+@Library('delorean-pipeline-library')
+
+def imageSyncOptions = [:]
+
+def verifyImageSyncOptions(options) {
+    if(!options.openshiftMasterUrl || !options.clusterAdminUsername || !options.clusterAdminPassword || !options.installationGitBranch || !options.installationGitUrl) {
+        def clusterAdminCredentials = setClusterAdminCredentials()
+        def userInput = input message: 'Image Sync Options', parameters: [
+            string(defaultValue: (options.openshiftMasterUrl ?: ''), description: 'OpenShift cluster public URL', name: 'openshiftMasterUrl'),
+            string(defaultValue: (options.clusterAdminUsername ?: clusterAdminCredentials.clusterAdminUsername), description: 'OpenShift cluster admin username', name: 'clusterAdminUsername'),
+            string(defaultValue: (options.clusterAdminPassword ?: clusterAdminCredentials.clusterAdminPassword), description: 'OpenShift cluster admin password', name: 'clusterAdminPassword'),
+            string(defaultValue: (options.installationGitUrl ?: 'https://github.com/integr8ly/installation.git'), description: 'Integreatly installer Git URL', name: 'installationGitUrl'),
+            string(defaultValue: (options.installationGitBranch ?: 'master'), description: 'Integreatly installer Git branch', name: 'installationGitBranch'),
+        ]
+        options.openshiftMasterUrl = userInput.openshiftMasterUrl
+        options.clusterAdminUsername = userInput.clusterAdminUsername
+        options.clusterAdminPassword = userInput.clusterAdminPassword
+        options.installationGitUrl = userInput.installationGitUrl
+        options.installationGitBranch = userInput.installationGitBranch
+        verifyImageSyncOptions(options)
+    }
+}
+
+def setClusterAdminCredentials() {
+    def integreatlyCredentialsID = 'tower-openshift-cluster-credentials'
+    def clusterAdminCredentials = [:]
+    withCredentials([usernamePassword(credentialsId: integreatlyCredentialsID, usernameVariable: 'CLUSTER_ADMIN_USERNAME', passwordVariable: 'CLUSTER_ADMIN_PASSWORD')]) {
+        clusterAdminCredentials.clusterAdminUsername = "${CLUSTER_ADMIN_USERNAME}"
+        clusterAdminCredentials.clusterAdminPassword = "${CLUSTER_ADMIN_PASSWORD}"
+    }
+
+    return clusterAdminCredentials
+}
+
+String getHost(String url) {
+    URI uri = new URI(url);
+    String[] urlParts = uri.getHost().split(/\./).takeRight(3)
+    return urlParts.join('.')
+}
+
+stage('Image Sync Options') {
+    def clusterAdminCredentials = setClusterAdminCredentials()
+    imageSyncOptions.openshiftMasterUrl = params.openshiftMasterUrl
+    imageSyncOptions.clusterAdminUsername = params.clusterAdminUsername ?: clusterAdminCredentials.clusterAdminUsername // Defaults to the username stored in tower-openshift-cluster-credentials
+    imageSyncOptions.clusterAdminPassword = params.clusterAdminPassword ?: clusterAdminCredentials.clusterAdminPassword // Defaults to the password stored in tower-openshift-cluster-credentials
+    imageSyncOptions.installationGitUrl = params.installationGitUrl
+    imageSyncOptions.installationGitBranch = params.installationGitBranch
+    verifyImageSyncOptions(imageSyncOptions)
+    
+    println "Image Sync Options: ${imageSyncOptions}"
+    currentBuild.displayName = "${currentBuild.displayName} ${imageSyncOptions.installationGitBranch}"
+    currentBuild.description = imageSyncOptions.openshiftMasterUrl
+}
+
+def githubSSHCredentialsID = 'jenkinsgithub'
+def imageSyncConfigFile = './integreatly.yml'
+String brewContainerRegistry
+def projectsToSync
+def syncImages = false
+
+node('cirhos_rhel7') {
+    cleanWs()
+    stage('Ensure Sync File Exists') {
+        dir('installation') {
+            gitCheckoutRepo(imageSyncOptions.installationGitUrl, imageSyncOptions.installationGitBranch, githubSSHCredentialsID, '.')
+            syncImages = fileExists imageSyncConfigFile
+
+            if (!syncImages) {
+                println "Image sync file '${imageSyncConfigFile}' is not available. No images to sync, skipping!"
+            }
+        }
+    }
+
+    stage('Get Images To Sync') {
+        when(syncImages) {
+            dir('installation') {
+                def imageSyncConfigContent = readYaml file: imageSyncConfigFile
+                projectsToSync = imageSyncConfigContent.imageSync
+                brewContainerRegistry = imageSyncConfigContent.sourceRepo
+            }
+        }
+    }
+
+    stage('Authenticate to OpenShift') {
+        when(syncImages) {
+            sh "oc login ${imageSyncOptions.openshiftMasterUrl} -u ${imageSyncOptions.clusterAdminUsername} -p ${imageSyncOptions.clusterAdminPassword} --insecure-skip-tls-verify"
+            imageSyncOptions.clusterAdminAuthToken = sh(returnStdout: true, script: "oc whoami -t").trim()
+        }
+    }
+
+    stage('Create Brew Projects') {
+        when(syncImages) {
+            String clusterContainerRegistryConsole = "registry-console-default.apps.${getHost(imageSyncOptions.openshiftMasterUrl)}" 
+            projectsToSync.keySet().each {
+                if (params.dryRun) {
+                    println "Would create a new project called '${it}' and set the registry project access policy to 'Anonymous: Allow all unauthenticated users to pull images'"
+                } else {
+                    sh "oc new-project ${it} || true"
+                    // Set registry project access policy to Anonymous: Allow all unauthenticated users to pull images
+                    sh "oc create rolebinding registry-viewer --clusterrole=registry-viewer || true"
+                    sh "oc adm policy add-role-to-group registry-viewer system:authenticated system:unauthenticated || true"
+                    println "https://${clusterContainerRegistryConsole}/registry#/projects/${it}"
+                }
+            }
+        }
+    }
+
+    stage('Sync Images') {
+        when(syncImages) { 
+            String clusterContainerRegistryPublic = "docker-registry-default.apps.${getHost(imageSyncOptions.openshiftMasterUrl)}"
+            projectsToSync.each { project, projectConfig ->
+                println "Syncing images for ${project}"
+                brewContainerRegistry = projectConfig.sourceRepo ?: brewContainerRegistry
+
+                if (!brewContainerRegistry) {
+                  error "Brew container registry was not specified"
+                } else {
+                    projectConfig.images.each {
+                        def brewImageUrl = "${brewContainerRegistry}/${project}/${it}"
+                        def clusterImageUrlPub = "${clusterContainerRegistryPublic}/${project}/${it}"
+
+                        if (params.dryRun) {
+                            println "Would copy the image '${it}' from ${brewImageUrl} to ${clusterImageUrlPub}"
+                        } else {
+                            retry(3) {
+                                sh """
+                                  skopeo copy \
+                                  --dest-creds ${imageSyncOptions.clusterAdminUsername}:${imageSyncOptions.clusterAdminAuthToken} \
+                                  --dest-tls-verify=false \
+                                  --src-tls-verify=false \
+                                  docker://${brewImageUrl} \
+                                  docker://${clusterImageUrlPub}
+                                """
+                            }
+                        }
+
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jobs/openshift/cluster/brew/openshift-cluster-brew-image-sync-1835.yaml
+++ b/jobs/openshift/cluster/brew/openshift-cluster-brew-image-sync-1835.yaml
@@ -1,0 +1,40 @@
+---
+- job:
+    name: openshift-cluster-brew-image-sync-1835
+    display-name: 'Openshift Cluster Brew Image Sync 1835'
+    project-type: pipeline
+    concurrent: true
+    parameters:
+      - string:
+          name: 'openshiftMasterUrl'
+          default: ''
+          description: '[REQUIRED] The public URL of the target OpenShift cluster'
+      - string:
+          name: 'clusterAdminUsername'
+          default: ''
+          description: '[OPTIONAL] Username of the cluster admin account. Defaults to the username stored in tower-openshift-cluster-credentials'
+      - string:
+          name: 'clusterAdminPassword'
+          default: ''
+          description: '[OPTIONAL] Password of the cluster admin account. Defaults to the password stored in tower-openshift-cluster-credentials'
+      - string:
+          name: 'installationGitUrl'
+          default: 'https://github.com/integr8ly/installation.git'
+          description: '[REQUIRED] Integreatly installer Git URL'
+      - string:
+          name: 'installationGitBranch'
+          default: 'master'
+          description: '[REQUIRED] The name of the git branch to be used for installing Integreatly'
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
+    pipeline-scm:
+      script-path: jobs/openshift/cluster/brew/Jenkinsfile
+      scm:
+        - git:
+            branches:
+              - 'master'
+            url: 'https://github.com/integr8ly/ci-cd.git'
+            skip-tag: true
+            wipe-workspace: false

--- a/jobs/openshift/cluster/brew/openshift-cluster-brew-image-sync.yaml
+++ b/jobs/openshift/cluster/brew/openshift-cluster-brew-image-sync.yaml
@@ -1,7 +1,7 @@
 ---
 - job:
-    name: openshift-cluster-brew-image-sync-1835
-    display-name: 'Openshift Cluster Brew Image Sync 1835'
+    name: openshift-cluster-brew-image-sync
+    display-name: 'Openshift Cluster Brew Image Sync'
     project-type: pipeline
     concurrent: true
     parameters:

--- a/jobs/openshift/cluster/integreatly/install/Jenkinsfile
+++ b/jobs/openshift/cluster/integreatly/install/Jenkinsfile
@@ -59,6 +59,20 @@ stage("Verify Installation Options") {
 
 node('cirhos_rhel7') {
     cleanWs()
+    stage('Pre-install') {
+      // Syncs brew images if an image sync config file is found
+      def jobName = 'openshift-cluster-brew-image-sync-1835'
+      def jobParams = [
+              [$class: 'StringParameterValue', name: 'openshiftMasterUrl', value: installerOptions.openshiftMasterUrl],
+              [$class: 'StringParameterValue', name: 'clusterAdminUsername', value: installerOptions.clusterAdminUsername],
+              [$class: 'StringParameterValue', name: 'clusterAdminPassword', value: installerOptions.clusterAdminPassword],
+              [$class: 'StringParameterValue', name: 'installationGitUrl', value: installerOptions.installationGitUrl],
+              [$class: 'StringParameterValue', name: 'installationGitBranch', value: installerOptions.installationGitBranch],
+              [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
+      ]
+      build job: jobName, parameters: jobParams
+    }
+
     stage('Install Integreatly') {
         if (params.dryRun) {
             println("Would call ansibleTower Integreatly Install Workflow template with the following installer options: ${installerOptions}")

--- a/jobs/openshift/cluster/integreatly/install/Jenkinsfile
+++ b/jobs/openshift/cluster/integreatly/install/Jenkinsfile
@@ -3,37 +3,37 @@
 def installerOptions = [:]
 
 def verifyInstallerOptions(installerOptions) {
-  if (!installerOptions.clusterName || !installerOptions.openshiftMasterUrl || !installerOptions.clusterAdminUsername || 
-      !installerOptions.clusterAdminPassword || !installerOptions.installationGitUrl || !installerOptions.installationGitBranch) {
-      def clusterAdminCredentials = setClusterAdminCredentials()
-      def userInput = input message: 'Installer Options', parameters: [
-        string(defaultValue: (installerOptions.clusterName ?: ''), description: 'Cluster name', name: 'clusterName'),
-        string(defaultValue: (installerOptions.openshiftMasterUrl ?: ''), description: 'OpenShift cluster public URL', name: 'openshiftMasterUrl'),
-        string(defaultValue: (installerOptions.clusterAdminUsername ?: clusterAdminCredentials.clusterAdminUsername), description: 'OpenShift cluster admin username', name: 'clusterAdminUsername'),
-        string(defaultValue: (installerOptions.clusterAdminPassword ?: clusterAdminCredentials.clusterAdminPassword), description: 'OpenShift cluster admin password', name: 'clusterAdminPassword'),
-        string(defaultValue: (installerOptions.installationGitUrl ?: 'https://github.com/integr8ly/installation.git'), description: 'Integreatly installer Git URL', name: 'installationGitUrl'),
-        string(defaultValue: (installerOptions.installationGitBranch ?: 'master'), description: 'Integreatly installer Git branch', name: 'installationGitBranch'),
-      ]
+    if (!installerOptions.clusterName || !installerOptions.openshiftMasterUrl || !installerOptions.clusterAdminUsername || 
+        !installerOptions.clusterAdminPassword || !installerOptions.installationGitUrl || !installerOptions.installationGitBranch) {
+            def clusterAdminCredentials = setClusterAdminCredentials()
+            def userInput = input message: 'Installer Options', parameters: [
+                string(defaultValue: (installerOptions.clusterName ?: ''), description: 'Cluster name', name: 'clusterName'),
+                string(defaultValue: (installerOptions.openshiftMasterUrl ?: ''), description: 'OpenShift cluster public URL', name: 'openshiftMasterUrl'),
+                string(defaultValue: (installerOptions.clusterAdminUsername ?: clusterAdminCredentials.clusterAdminUsername), description: 'OpenShift cluster admin username', name: 'clusterAdminUsername'),
+                string(defaultValue: (installerOptions.clusterAdminPassword ?: clusterAdminCredentials.clusterAdminPassword), description: 'OpenShift cluster admin password', name: 'clusterAdminPassword'),
+                string(defaultValue: (installerOptions.installationGitUrl ?: 'https://github.com/integr8ly/installation.git'), description: 'Integreatly installer Git URL', name: 'installationGitUrl'),
+                string(defaultValue: (installerOptions.installationGitBranch ?: 'master'), description: 'Integreatly installer Git branch', name: 'installationGitBranch'),
+            ]
 
-      installerOptions.clusterName = userInput.clusterName
-      installerOptions.openshiftMasterUrl = userInput.openshiftMasterUrl
-      installerOptions.clusterAdminUsername = userInput.clusterAdminUsername
-      installerOptions.clusterAdminPassword = userInput.clusterAdminPassword
-      installerOptions.installationGitUrl = userInput.installationGitUrl
-      installerOptions.installationGitBranch = userInput.installationGitBranch
-      verifyInstallerOptions(installerOptions)
-  }
+            installerOptions.clusterName = userInput.clusterName
+            installerOptions.openshiftMasterUrl = userInput.openshiftMasterUrl
+            installerOptions.clusterAdminUsername = userInput.clusterAdminUsername
+            installerOptions.clusterAdminPassword = userInput.clusterAdminPassword
+            installerOptions.installationGitUrl = userInput.installationGitUrl
+            installerOptions.installationGitBranch = userInput.installationGitBranch
+            verifyInstallerOptions(installerOptions)
+    }
 }
 
 def setClusterAdminCredentials() {
-  def integreatlyCredentialsID = 'tower-openshift-cluster-credentials'
-  def clusterAdminCredentials = [:]
-  withCredentials([usernamePassword(credentialsId: integreatlyCredentialsID, usernameVariable: 'CLUSTER_ADMIN_USERNAME', passwordVariable: 'CLUSTER_ADMIN_PASSWORD')]) {
-    clusterAdminCredentials.clusterAdminUsername = "${CLUSTER_ADMIN_USERNAME}"
-    clusterAdminCredentials.clusterAdminPassword = "${CLUSTER_ADMIN_PASSWORD}"
-  }
+    def integreatlyCredentialsID = 'tower-openshift-cluster-credentials'
+    def clusterAdminCredentials = [:]
+    withCredentials([usernamePassword(credentialsId: integreatlyCredentialsID, usernameVariable: 'CLUSTER_ADMIN_USERNAME', passwordVariable: 'CLUSTER_ADMIN_PASSWORD')]) {
+        clusterAdminCredentials.clusterAdminUsername = "${CLUSTER_ADMIN_USERNAME}"
+        clusterAdminCredentials.clusterAdminPassword = "${CLUSTER_ADMIN_PASSWORD}"
+    }
 
-  return clusterAdminCredentials
+    return clusterAdminCredentials
 }
 
 stage("Verify Installation Options") {
@@ -57,46 +57,46 @@ stage("Verify Installation Options") {
                                 \nselfSignedCerts: ${installerOptions.selfSignedCerts}\nawsCredentials:${installerOptions.awsCredentials}"""
 }
 
+stage('Pre-install') {
+    // Syncs brew images if an image sync config file is found
+    def jobName = 'openshift-cluster-brew-image-sync'
+    def jobParams = [
+        [$class: 'StringParameterValue', name: 'openshiftMasterUrl', value: installerOptions.openshiftMasterUrl],
+        [$class: 'StringParameterValue', name: 'clusterAdminUsername', value: installerOptions.clusterAdminUsername],
+        [$class: 'StringParameterValue', name: 'clusterAdminPassword', value: installerOptions.clusterAdminPassword],
+        [$class: 'StringParameterValue', name: 'installationGitUrl', value: installerOptions.installationGitUrl],
+        [$class: 'StringParameterValue', name: 'installationGitBranch', value: installerOptions.installationGitBranch],
+        [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
+    ]
+    build job: jobName, parameters: jobParams
+}
+
 node('cirhos_rhel7') {
     cleanWs()
-    stage('Pre-install') {
-      // Syncs brew images if an image sync config file is found
-      def jobName = 'openshift-cluster-brew-image-sync-1835'
-      def jobParams = [
-              [$class: 'StringParameterValue', name: 'openshiftMasterUrl', value: installerOptions.openshiftMasterUrl],
-              [$class: 'StringParameterValue', name: 'clusterAdminUsername', value: installerOptions.clusterAdminUsername],
-              [$class: 'StringParameterValue', name: 'clusterAdminPassword', value: installerOptions.clusterAdminPassword],
-              [$class: 'StringParameterValue', name: 'installationGitUrl', value: installerOptions.installationGitUrl],
-              [$class: 'StringParameterValue', name: 'installationGitBranch', value: installerOptions.installationGitBranch],
-              [$class: 'BooleanParameterValue', name: 'dryRun', value: params.dryRun]
-      ]
-      build job: jobName, parameters: jobParams
-    }
-
     stage('Install Integreatly') {
         if (params.dryRun) {
             println("Would call ansibleTower Integreatly Install Workflow template with the following installer options: ${installerOptions}")
         } else {
             wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
-              ansibleTower(
-                towerServer: 'Dev Tower',
-                jobTemplate: 'Integreatly Install Workflow',
-                templateType: 'workflow',
-                importTowerLogs: true,
-                removeColor: false,
-                verbose: true,
-                extraVars: """---
-                  tower_environment: dev
-                  cluster_name: ${installerOptions.clusterName}
-                  openshift_master_public_url: ${installerOptions.openshiftMasterUrl}
-                  openshift_username: ${installerOptions.clusterAdminUsername}
-                  openshift_password: ${installerOptions.clusterAdminPassword}
-                  integreatly_project_install_scm_url: ${installerOptions.installationGitUrl}
-                  integreatly_project_install_scm_branch: ${installerOptions.installationGitBranch}
-                  eval_seed_users_count: ${installerOptions.userCount}
-                  eval_self_signed_certs: '${installerOptions.selfSignedCerts}'
-                  integreatly_inventory_source_aws_credentials: ${installerOptions.awsCredentials}"""
-              )
+                ansibleTower(
+                    towerServer: 'Dev Tower',
+                    jobTemplate: 'Integreatly Install Workflow',
+                    templateType: 'workflow',
+                    importTowerLogs: true,
+                    removeColor: false,
+                    verbose: true,
+                    extraVars: """---
+                    tower_environment: dev
+                    cluster_name: ${installerOptions.clusterName}
+                    openshift_master_public_url: ${installerOptions.openshiftMasterUrl}
+                    openshift_username: ${installerOptions.clusterAdminUsername}
+                    openshift_password: ${installerOptions.clusterAdminPassword}
+                    integreatly_project_install_scm_url: ${installerOptions.installationGitUrl}
+                    integreatly_project_install_scm_branch: ${installerOptions.installationGitBranch}
+                    eval_seed_users_count: ${installerOptions.userCount}
+                    eval_self_signed_certs: '${installerOptions.selfSignedCerts}'
+                    integreatly_inventory_source_aws_credentials: ${installerOptions.awsCredentials}"""
+                )
             }
         }
     }

--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -67,6 +67,7 @@ generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/deprovision/op
 generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-install.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-uninstall.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-test.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/brew/openshift-cluster-brew-image-sync-1835.yaml
 
 #Delorean Folders
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/delorean/folders.yaml


### PR DESCRIPTION
## What
A pre install stage needs to added to the `Openshift Cluster Integreatly Install` pipeline. This should complete any tasks required before the installation of integreatly is triggered.
- [x] add job for syncing images from brew to the cluster registry to be used for RC testing
- [x] add a preinstall stage to the installation pipeline
    - Trigger a build for `Openshift Cluster Integreatly Brew Images Sync` from this stage to ensure that RC images will be available during installation

Image sync config file format:
```
imageSync:
  sourceRepo: <default-source-repo>
  projects:
    <project-name>:
      images:
      - [images]
    <project-name>:
      sourceRepo: <source-repo>
      images:
      - [images]
...
```