### PR TITLE
fix the name of the brew image sync file in the jenkins configuration script

### DIFF
--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -67,7 +67,7 @@ generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/deprovision/op
 generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-install.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-uninstall.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/integreatly/openshift-cluster-integreatly-test.yaml
-generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/brew/openshift-cluster-brew-image-sync-1835.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/brew/openshift-cluster-brew-image-sync.yaml
 
 #Delorean Folders
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/delorean/folders.yaml


### PR DESCRIPTION
## What
- [x] Remove the `-1835` from the file name of the `Openshift Cluster Brew Image Sync` pipeline in the Jenkins configuration script