### PR TITLE
Adjust schedule of timed executions of GA discovery jobs.

### DIFF
--- a/jobs/delorean/3scale/ga/discovery.yaml
+++ b/jobs/delorean/3scale/ga/discovery.yaml
@@ -5,7 +5,7 @@
     project-type: pipeline
     concurrent: false
     triggers:
-      - timed: '@hourly'
+      - timed: '@daily'
     parameters:
       - string:
           name: 'productVersionVar'

--- a/jobs/delorean/amq-online/ga/discovery.yaml
+++ b/jobs/delorean/amq-online/ga/discovery.yaml
@@ -5,7 +5,7 @@
     project-type: pipeline
     concurrent: false
     triggers:
-      - timed: '@hourly'
+      - timed: '@daily'
     parameters:
       - string:
           name: 'productVersionVar'

--- a/jobs/delorean/backup-container/ga/discovery.yaml
+++ b/jobs/delorean/backup-container/ga/discovery.yaml
@@ -5,7 +5,7 @@
     project-type: pipeline
     concurrent: false
     triggers:
-      - timed: 'H/10 * * * *'
+      - timed: '@hourly'
     parameters:
       - string:
           name: 'productVersionVar'

--- a/jobs/delorean/codeready/ga/discovery.yaml
+++ b/jobs/delorean/codeready/ga/discovery.yaml
@@ -5,7 +5,7 @@
     project-type: pipeline
     concurrent: false
     triggers:
-      - timed: '@hourly'
+      - timed: '@daily'
     parameters:
       - string:
           name: 'productVersionVar'

--- a/jobs/delorean/fuse-online/ga/discovery.yaml
+++ b/jobs/delorean/fuse-online/ga/discovery.yaml
@@ -5,7 +5,7 @@
     project-type: pipeline
     concurrent: false
     triggers:
-      - timed: '@hourly'
+      - timed: '@daily'
     parameters:
       - string:
           name: 'releaseTagVar'

--- a/jobs/delorean/fuse/ga/discovery.yaml
+++ b/jobs/delorean/fuse/ga/discovery.yaml
@@ -5,7 +5,7 @@
     project-type: pipeline
     concurrent: false
     triggers:
-      - timed: '@hourly'
+      - timed: '@daily'
     parameters:
       - string:
           name: 'manifestVar'

--- a/jobs/delorean/gitea/ga/discovery.yaml
+++ b/jobs/delorean/gitea/ga/discovery.yaml
@@ -5,7 +5,7 @@
     project-type: pipeline
     concurrent: false
     triggers:
-      - timed: 'H/10 * * * *'
+      - timed: '@hourly'
     parameters:
       - string:
           name: 'releaseTagVar'

--- a/jobs/delorean/keycloak/ga/discovery.yaml
+++ b/jobs/delorean/keycloak/ga/discovery.yaml
@@ -5,7 +5,7 @@
     project-type: pipeline
     concurrent: false
     triggers:
-     - timed: '@hourly'
+      - timed: '@daily'
     parameters:
       - string:
           name: 'installationGitUrl'

--- a/jobs/delorean/middleware-monitoring/ga/discovery.yaml
+++ b/jobs/delorean/middleware-monitoring/ga/discovery.yaml
@@ -5,7 +5,7 @@
     project-type: pipeline
     concurrent: false
     triggers:
-      - timed: 'H/10 * * * *'
+      - timed: '@hourly'
     parameters:
       - string:
           name: 'releaseTagVar'

--- a/jobs/delorean/msbroker/ga/discovery.yaml
+++ b/jobs/delorean/msbroker/ga/discovery.yaml
@@ -5,7 +5,7 @@
     project-type: pipeline
     concurrent: false
     triggers:
-      - timed: 'H/10 * * * *'
+      - timed: '@hourly'
     parameters:
       - string:
           name: 'releaseTagVar'

--- a/jobs/delorean/rhsso/ga/discovery.yaml
+++ b/jobs/delorean/rhsso/ga/discovery.yaml
@@ -5,7 +5,7 @@
     project-type: pipeline
     concurrent: false
     triggers:
-      - timed: 'H/10 * * * *'
+      - timed: '@hourly'
     parameters:
       - string:
           name: 'releaseTagVar'

--- a/jobs/delorean/webapp/ga/discovery.yaml
+++ b/jobs/delorean/webapp/ga/discovery.yaml
@@ -5,7 +5,7 @@
     project-type: pipeline
     concurrent: false
     triggers:
-      - timed: 'H/10 * * * *'
+      - timed: '@hourly'
     parameters:
       - string:
           name: 'releaseTagVar'


### PR DESCRIPTION
* All external products are checked daily (fuse, amq, 3scale etc..)
* All internal components are checked hourly (msbroker, webapp etc...)

We're getting lots of failed builds currently due to GH rate limits. This is just a quick change to stop trying to discover new versions as often. https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Delorean/builds

I think longer term a daily timed check for everything will be suitable (We can always trigger manually if needs be), if we can also look at adding a webhook trigger for our own internal components which change far more frequently.
