### PR TITLE
Moved alerts test to be executed last

### DIFF
--- a/jobs/integr8ly/all-tests-executor.yaml
+++ b/jobs/integr8ly/all-tests-executor.yaml
@@ -135,12 +135,12 @@
                         runTests('w1-test-executor')
                     } // stage
 
-                    stage ('Alerts test') {
-                        runTests('alerts-test')
-                    } // stage
-
                     stage ('Nexus builds test') {
                         runTests('nexus-builds-test')
+                    } // stage
+
+                    stage ('Alerts test') {
+                        runTests('alerts-test')
                     } // stage
 
                 } // node


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

I noticed a few times that the alerts.js test failed due to more than one alert not being green nightly. In the morning all alerts were ok though. It takes some time for the alerts to get green after installation so (as a quick fix) I moved the alerts test to be executed last. This might help mitigate the issue a bit.

We might need to come up with better solution on alerts.js code level though.

Verification steps

`jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/all-tests-executor.yaml`

I don't believe it is necessary for such a simple modification, but you can also run all-test-executor using my branch to verify
