### PR TITLE
Intly 1692: Add stage to verify that latest release is GA

### DIFF
--- a/jobs/delorean/fuse-online/ga/discovery.yaml
+++ b/jobs/delorean/fuse-online/ga/discovery.yaml
@@ -28,6 +28,16 @@
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
       - string:
+          name: 'templatesDir'
+          default: 'resources'
+          description: '[REQUIRED] directory where openshift templates are located'
+          read-only: true
+      - string:
+          name: 'registryProjectIDs'
+          default: 'fuse7, fuse7-tech-preview'
+          description: '[REQUIRED] registry image projects'
+          read-only: true
+      - string:
           name: 'releaseFetchMethod'
           default: 'tag'
           description: '[REQUIRED] Method to fetch latest release which can either be by tag or by release'

--- a/jobs/delorean/fuse-online/rc/discovery.yaml
+++ b/jobs/delorean/fuse-online/rc/discovery.yaml
@@ -39,7 +39,7 @@
           read-only: true
       - string:
           name: 'registryProjectIDs'
-          default: 'fuse7'
+          default: 'fuse7, fuse7-tech-preview'
           description: '[REQUIRED] registry image projects'
           read-only: true
       - bool:

--- a/jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
@@ -26,6 +26,7 @@ String rhContainerRegistry = "registry.redhat.io"
 String rhContainerRegistry2 = "registry.access.redhat.com"
 def rhRegistries = [rhContainerRegistry, rhContainerRegistry2]
 def targetRegistrySecret = 'intly-redhat-registry-sa'
+Boolean verifyReleaseIsGA = (templatesDir && registryProjectIDs) ? true : false
 
 currentBuild.displayName = "${currentBuild.displayName} ${productName}"
 
@@ -65,7 +66,7 @@ node {
     }
 
     stage('Verify GA Release') {
-        if (templatesDir && registryProjectIDs) {
+        when(verifyReleaseIsGA) {
             dir(productName) {
                 productGitUrl = "git@github.com:${projectOrg}/${projectRepo}.git"
                 gitCheckoutRepo(productGitUrl, latestRelease, githubSSHCredentialsID, '.')

--- a/jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
@@ -72,7 +72,7 @@ node {
                 
                 dir(templatesDir) {
                     registryProjectIDs = registryProjectIDs.replaceAll(" ", "").split(',')
-                    // Get product images (ignore fuse-online-upgrade)
+                    // Get product images from public registries
                     def productImages = rhRegistries.collect { registry ->
                         registryProjectIDs.collect { registryID ->
                             // Ignore the file fuse-online-upgrade as it contains an image with a typo (registry.redhat.io/fuse7/fuse-ignite-uprade)
@@ -80,28 +80,33 @@ node {
                         }
                     }.flatten() - null - ''
 
-                    // Check if the product images are available for GA
-                    def preReleaseImages = productImages.collect { imageUrl ->
-                        def image = new RegistryImage(imageUrl)
-                        try {
-                            def params = [
-                                credentials: targetRegistrySecret,
-                                host: image.getHttpsHost(),
-                                image: image.getPath(),
-                                tag: image.getTag()
-                            ]
-                            registryHasImage(params) ? null : imageUrl
-                        } catch (Exception e) {
-                            println "Failed to check the availability of ${imageUrl}, adding image to preReleaseImages"
-                            imageUrl
-                        }
-                    }.flatten() - null - ''
-
-                    if (preReleaseImages.size != 0) {
-                      println "${latestRelease} is not GA. The following images are not yet available: ${preReleaseImages}"
+                    if (productImages.size() == 0) {
+                      println "${latestRelease} is not GA. There are no images available in public registries."
                       latestRelease = componentRelease
                     } else {
-                      println "Verified that the latest release ${latestRelease} is GA"
+                        // Check if the product images are available for GA
+                        def preReleaseImages = productImages.collect { imageUrl ->
+                            def image = new RegistryImage(imageUrl)
+                            try {
+                                def params = [
+                                    credentials: targetRegistrySecret,
+                                    host: image.getHttpsHost(),
+                                    image: image.getPath(),
+                                    tag: image.getTag()
+                                ]
+                                registryHasImage(params) ? null : imageUrl
+                            } catch (Exception e) {
+                                println "Failed to check the availability of ${imageUrl}, adding image to preReleaseImages"
+                                imageUrl
+                            }
+                        }.flatten() - null - ''
+
+                        if (preReleaseImages.size != 0) {
+                          println "${latestRelease} is not GA. The following images are not yet available: ${preReleaseImages}"
+                          latestRelease = componentRelease
+                        } else {
+                          println "Verified that the latest release ${latestRelease} is GA"
+                        }
                     }
                 }
             }

--- a/jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
@@ -1,5 +1,7 @@
 #!groovy
-@Library('delorean-pipeline-library')
+@Library('delorean-pipeline-library') _
+
+import org.integr8ly.RegistryImage
 
 def installationGitUrl = params.installationGitUrl ?: 'git@github.com:integr8ly/installation.git'
 def installationGitRef = params.installationGitRef ?: 'master'
@@ -17,6 +19,13 @@ def gaBranch = params.installationProductBranch ?: "${productName}-ga"
 def gaReleaseTagRef = params.gaReleaseTagRef ?: ''
 def installationManifestFile = './inventories/group_vars/all/manifest.yaml'
 def isProduct = params.isProduct ?: false
+
+def templatesDir = params.templatesDir
+def registryProjectIDs = params.registryProjectIDs
+String rhContainerRegistry = "registry.redhat.io"
+String rhContainerRegistry2 = "registry.access.redhat.com"
+def rhRegistries = [rhContainerRegistry, rhContainerRegistry2]
+def targetRegistrySecret = 'intly-redhat-registry-sa'
 
 currentBuild.displayName = "${currentBuild.displayName} ${productName}"
 
@@ -53,6 +62,50 @@ node {
             error "[ERROR] Unable to retrieve latest release version!"
         }
         println "[INFO] latestRelease = ${latestRelease}"
+    }
+
+    stage('Verify GA Release') {
+        if (templatesDir && registryProjectIDs) {
+            dir(productName) {
+                productGitUrl = "git@github.com:${projectOrg}/${projectRepo}.git"
+                gitCheckoutRepo(productGitUrl, latestRelease, githubSSHCredentialsID, '.')
+                
+                dir(templatesDir) {
+                    registryProjectIDs = registryProjectIDs.replaceAll(" ", "").split(',')
+                    // Get product images (ignore fuse-online-upgrade)
+                    def productImages = rhRegistries.collect { registry ->
+                        registryProjectIDs.collect { registryID ->
+                            // Ignore the file fuse-online-upgrade as it contains an image with a typo (registry.redhat.io/fuse7/fuse-ignite-uprade)
+                            sh(returnStdout: true, script: "find . -name \'*.y*ml\' ! -name \'fuse-online-upgrade.yml\' -exec grep -oP \'${registry}/${registryID}.*/[^[:blank:]].*\' {} \\; | sort | uniq").replace('"', '').split('\n')
+                        }
+                    }.flatten() - null - ''
+
+                    // Check if the product images are available for GA
+                    def preReleaseImages = productImages.collect { imageUrl ->
+                        def image = new RegistryImage(imageUrl)
+                        try {
+                            def params = [
+                                credentials: targetRegistrySecret,
+                                host: image.getHttpsHost(),
+                                image: image.getPath(),
+                                tag: image.getTag()
+                            ]
+                            registryHasImage(params) ? null : imageUrl
+                        } catch (Exception e) {
+                            println "Failed to check the availability of ${imageUrl}, adding image to preReleaseImages"
+                            imageUrl
+                        }
+                    }.flatten() - null - ''
+
+                    if (preReleaseImages.size != 0) {
+                      println "${latestRelease} is not GA. The following images are not yet available: ${preReleaseImages}"
+                      latestRelease = componentRelease
+                    } else {
+                      println "Verified that the latest release ${latestRelease} is GA"
+                    }
+                }
+            }
+        }
     }
 
     stage('Fetch Component Product Version') {

--- a/jobs/delorean/jenkinsfiles/discovery/rc/github/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/discovery/rc/github/Jenkinsfile
@@ -33,7 +33,7 @@ String clusterContainerRegistryPrivate = "docker-registry.default.svc:5000"
 def rhRegistries = [brewContainerRegistry, rhContainerRegistry, rhContainerRegistry2]
 def productImages = []
 def productPreReleaseImages = []
-def registryProjectIDs = params.registryProjectIDs.split(',')
+def registryProjectIDs = params.registryProjectIDs.replaceAll(" ", "").split(',')
 
 currentBuild.displayName = "${currentBuild.displayName} ${productName}"
 
@@ -124,7 +124,8 @@ node {
                     productImages = rhRegistries.collect { registry ->
                         registryProjectIDs.collect { registryID ->
                             println "Checking for registry: ${registry}, registryID: ${registryID}"
-                            sh(returnStdout: true, script: "find . -name \'*.y*ml\' -exec grep -oP \'${registry}/${registryID}.*/[^[:blank:]].*\' {} \\; | sort | uniq").replace('"', '').split('\n')
+                            // Ignore fuse-online-upgrade as it contains an image with a typo (registry.redhat.io/fuse7/fuse-ignite-uprade)
+                            sh(returnStdout: true, script: "find . -name \'*.y*ml\' ! -name \'fuse-online-upgrade.yml\' -exec grep -oP \'${registry}/${registryID}.*/[^[:blank:]].*\' {} \\; | sort | uniq").replace('"', '').split('\n')
                         }
                     }.flatten() - null - ''
                     productImages = productImages.unique()
@@ -149,7 +150,6 @@ node {
                         ]
                         registryHasImage(params) ? null : imageUrl
                     } catch (Exception e) {
-                        //ToDo Unsure what to do here, some images don't appear to be made available on registry.redhat.io (fuse7/fuse-postgres-exporter and fuse7/fuse-ignite-uprade)
                         println "Failed checking ${image.getPath()} with ${image.getTag()}, adding image to productPreReleaseImages"
                         imageUrl
                     }


### PR DESCRIPTION
## What
Some of the products (i.e. Fuse Online) create tags before releasing the images officially. These tags may contain private image repositories or images that are not yet available in the normal registries.

- [x] Add a stage `Verify GA Release` to verify if the latest release discovered is actually GA
    - Find all product images from the files in the product's template directory
         - Ignore the file `fuse-online-upgrade` for Fuse online as it contains an image that does not exist in the repository [[1](https://github.com/syndesisio/fuse-online-install/issues/131)].
    - Check if the product images are available in the normal registries.
- [x] Add the following parameters to the Fuse online GA discovery job
    - `templatesDir`
    - `registryProjectIDs`
        - The `fuse7-tech-preview` should contain the image for postgres-exporter

[1] https://github.com/syndesisio/fuse-online-install/issues/131
