### PR TITLE
INTLY-2248

### DIFF
--- a/jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
@@ -70,45 +70,32 @@ node {
             dir(productName) {
                 productGitUrl = "git@github.com:${projectOrg}/${projectRepo}.git"
                 gitCheckoutRepo(productGitUrl, latestRelease, githubSSHCredentialsID, '.')
-                
-                dir(templatesDir) {
-                    registryProjectIDs = registryProjectIDs.replaceAll(" ", "").split(',')
-                    // Get product images from public registries
-                    def productImages = rhRegistries.collect { registry ->
-                        registryProjectIDs.collect { registryID ->
-                            // Ignore the file fuse-online-upgrade as it contains an image with a typo (registry.redhat.io/fuse7/fuse-ignite-uprade)
-                            sh(returnStdout: true, script: "find . -name \'*.y*ml\' ! -name \'fuse-online-upgrade.yml\' -exec grep -oP \'${registry}/${registryID}.*/[^[:blank:]].*\' {} \\; | sort | uniq").replace('"', '').split('\n')
-                        }
-                    }.flatten() - null - ''
+                registryProjectIDs = registryProjectIDs.replaceAll(" ", "").split(',')
 
-                    if (productImages.size() == 0) {
-                      println "${latestRelease} is not GA. There are no images available in public registries."
-                      latestRelease = componentRelease
-                    } else {
-                        // Check if the product images are available for GA
-                        def preReleaseImages = productImages.collect { imageUrl ->
-                            def image = new RegistryImage(imageUrl)
-                            try {
-                                def params = [
-                                    credentials: targetRegistrySecret,
-                                    host: image.getHttpsHost(),
-                                    image: image.getPath(),
-                                    tag: image.getTag()
-                                ]
-                                registryHasImage(params) ? null : imageUrl
-                            } catch (Exception e) {
-                                println "Failed to check the availability of ${imageUrl}, adding image to preReleaseImages"
-                                imageUrl
-                            }
-                        }.flatten() - null - ''
+                def getProductImagesParams = [
+                    targetDir: templatesDir,
+                    excludeFiles: ['fuse-online-upgrade.yml'], // Ignore the file fuse-online-upgrade as it contains an image with a typo (registry.redhat.io/fuse7/fuse-ignite-uprade)
+                    registries: rhRegistries,
+                    registryIDs: registryProjectIDs
+                ]
+                def productImages = getProductImages(getProductImagesParams)
 
-                        if (preReleaseImages.size != 0) {
-                          println "${latestRelease} is not GA. The following images are not yet available: ${preReleaseImages}"
-                          latestRelease = componentRelease
-                        } else {
-                          println "Verified that the latest release ${latestRelease} is GA"
-                        }
-                    }
+                if (productImages.size() == 0) {
+                    println "${latestRelease} is not GA. There are no images available using public registries."
+                    latestRelease = componentRelease
+                }
+
+                def getPreReleaseImagesParams = [
+                    imageUrls: productImages,
+                    registryCredentials: targetRegistrySecret
+                ]
+                def preReleaseImages = getPreReleaseImages(getPreReleaseImagesParams)
+
+                if (preReleaseImages.size != 0) {
+                    println "${latestRelease} is not GA. The following images are not yet available: ${preReleaseImages}"
+                    latestRelease = componentRelease
+                } else {
+                    println "Verified that the latest release ${latestRelease} is GA"
                 }
             }
         }

--- a/jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
@@ -95,7 +95,7 @@ node {
                     println "${latestRelease} is not GA. The following images are not yet available: ${preReleaseImages}"
                     latestRelease = componentRelease
                 } else {
-                    println "Verified that the latest release ${latestRelease} is GA"
+                    println "Found ${preReleaseImages.size()} prerelease images. Verified that the latest release ${latestRelease} is GA"
                 }
             }
         }

--- a/jobs/delorean/jenkinsfiles/discovery/rc/github/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/discovery/rc/github/Jenkinsfile
@@ -120,40 +120,29 @@ node {
             sh "git fetch --all"
 
             stage('Collect Product Images') {
-                dir(templatesDir) {
-                    productImages = rhRegistries.collect { registry ->
-                        registryProjectIDs.collect { registryID ->
-                            println "Checking for registry: ${registry}, registryID: ${registryID}"
-                            // Ignore fuse-online-upgrade as it contains an image with a typo (registry.redhat.io/fuse7/fuse-ignite-uprade)
-                            sh(returnStdout: true, script: "find . -name \'*.y*ml\' ! -name \'fuse-online-upgrade.yml\' -exec grep -oP \'${registry}/${registryID}.*/[^[:blank:]].*\' {} \\; | sort | uniq").replace('"', '').split('\n')
-                        }
-                    }.flatten() - null - ''
-                    productImages = productImages.unique()
-                }
+                def getProductImagesParams = [
+                    targetDir: templatesDir,
+                    excludeFiles: ['fuse-online-upgrade.yml'], // Ignore the file fuse-online-upgrade as it contains an image with a typo (registry.redhat.io/fuse7/fuse-ignite-uprade)
+                    registries: rhRegistries,
+                    registryIDs: registryProjectIDs
+                ]
+                productImages = getProductImages(getProductImagesParams)
+              
                 println "[INFO] Found ${productImages.size()} product images"
                 currentBuild.description = currentBuild.description + "\nImages: ${productImages.size()}\n"
             }
 
             stage('Collect Product Pre Release Images') {
-                //iterate over productImages and produce an array of images that are not GA
                 def targetRegistrySecret = 'intly-redhat-registry-sa'
                 def targetRegistryHost = 'https://registry.redhat.io'
-                productPreReleaseImages = productImages.collect { imageUrl ->
-                    println "Verify Pre Release image: ${imageUrl}"
-                    def image = new RegistryImage(imageUrl)
-                    try {
-                        def params = [
-                                credentials: targetRegistrySecret,
-                                host: targetRegistryHost,
-                                image: image.getPath(),
-                                tag: image.getTag()
-                        ]
-                        registryHasImage(params) ? null : imageUrl
-                    } catch (Exception e) {
-                        println "Failed checking ${image.getPath()} with ${image.getTag()}, adding image to productPreReleaseImages"
-                        imageUrl
-                    }
-                }.flatten() - null - ''
+
+                def getPreReleaseImagesParams = [
+                    imageUrls: productImages,
+                    registryCredentials: targetRegistrySecret,
+                    registryHost: targetRegistryHost
+                ]
+                productPreReleaseImages = getPreReleaseImages(getPreReleaseImagesParams)
+
                 println "[INFO] Found ${productPreReleaseImages.size()} pre release product images"
                 currentBuild.description = currentBuild.description + "\nPre Release Images: ${productPreReleaseImages.size()}\n"
             }


### PR DESCRIPTION
## What
Both the GA and the RC service discovery jobs checks for the availability of the product images in the public registry. Common code is extracted and moved to the library.

- [x] Use the var `getProductImages` to retrieve images from the templates directory
- [x] Use the var `getPreReleaseImages` to retrieve images that are not available in the public registry.

NOTE: To be tested with https://github.com/integr8ly/delorean-pipeline-library/pull/9