### PR TITLE
Added clean unistall pipeline on dynammic POC

### DIFF
--- a/jobs/integr8ly/tower-clean-uninstall.yaml
+++ b/jobs/integr8ly/tower-clean-uninstall.yaml
@@ -1,0 +1,113 @@
+---
+
+- job:
+    name: tower-clean-uninstall
+    description: 'Uninstalls Integreatly from fresh pure cluster created by Ansible Tower tooling where Integreatly has never been installed.'
+    project-type: pipeline
+    sandbox: false
+    concurrent: false
+    properties:
+      - build-discarder:
+          num-to-keep: 20
+    parameters:
+      - string:
+          name: REPOSITORY
+          default: 'https://github.com/integr8ly/installation.git'
+          description: 'Repository of the Integreatly installer'
+      - string:
+          name: BRANCH
+          default: 'master'
+          description: 'Branch of the installer repository'
+      - string:
+          name: RECIPIENTS
+          default: integreatly-qe@redhat.com
+          description: 'Whitespace- or comma-separated list of recipient addresses'
+    triggers:
+      - timed: 'H H(0-3) * * *'
+    dsl: |
+
+        def setClusterAdminCredentials() {
+            def integreatlyCredentialsID = 'tower-openshift-cluster-credentials'
+            def clusterAdminCredentials = [:]
+            withCredentials([usernamePassword(credentialsId: integreatlyCredentialsID, usernameVariable: 'CLUSTER_ADMIN_USERNAME', passwordVariable: 'CLUSTER_ADMIN_PASSWORD')]) {
+                clusterAdminCredentials.clusterAdminUsername = "${CLUSTER_ADMIN_USERNAME}"
+                clusterAdminCredentials.clusterAdminPassword = "${CLUSTER_ADMIN_PASSWORD}"
+            }
+
+            return clusterAdminCredentials
+        }
+
+        timeout(120) { ansiColor('gnome-terminal') { timestamps {
+            node('cirhos_rhel7') {
+                String clusterName = 'qe-uninstall'
+                String clusterDomainName = 'skunkhenry.com'
+                String awsRegion = 'eu-west-2'
+
+                try {
+                    stage ('Trigger Cluster Create') {
+                        build job: 'openshift-cluster-create', parameters: [
+                            string(name: 'clusterName', value: "${clusterName}"),
+                            string(name: 'awsRegion', value: "${awsRegion}"),
+                            string(name: 'compute_group_size', value: '1'),
+                            string(name: 'infra_group_size', value: '1')]
+                    } // stage
+
+                    stage('Clone the installer') {
+                        dir('installation') {
+                            checkout scm: [
+                                        $class: 'GitSCM', 
+                                        userRemoteConfigs: [[url: REPOSITORY]], 
+                                        branches: [[name: BRANCH]]
+                                        ]
+                        } // dir
+                    } // stage
+
+                    stage('Prepare environment') {
+                        dir('installation') {
+                            sh """
+                                cp ./inventories/hosts.template ./inventories/hosts
+                                sed -i 's/ansible_user=ec2-user/ansible_user=root/g' ./inventories/hosts
+                            """
+
+                            def clusterAdminCredentials = setClusterAdminCredentials()
+
+                            // This returns an external IP of a master node of a newly created cluster
+                            def masterIP = sh(
+                                returnStdout: true,
+                                script: """
+                                    oc login https://${clusterName}.${clusterDomainName} -u ${clusterAdminCredentials.clusterAdminUsername} -p ${clusterAdminCredentials.clusterAdminPassword} > /dev/null
+                                    oc describe node `oc get nodes | grep master | head -n 1 | awk '{print \$1}'` | grep ExternalIP | awk '{print \$2}'
+                                """).trim()
+
+                            sh """
+                                sed -i '\$!N;s@\\[master\\]\\n127.0.0.1@[master]\\n${masterIP}@;P;D' ./inventories/hosts
+                            """
+
+                            println readFile('./inventories/hosts')
+                        } // dir
+                    } // stage
+
+                    stage('Uninstall') {
+                        dir('installation') {
+                            withCredentials([sshUserPrivateKey(credentialsId: 'tower-provisioner-pem', keyFileVariable: 'private_key')]){
+                              sh """
+                                  ansible-playbook -i ./inventories/hosts --private-key ${private_key} ./playbooks/uninstall.yml
+                              """
+                            } // withCredentials
+                        } // dir
+                    } // stage
+
+                } catch (any) {
+                    currentBuild.result = 'FAILURE'
+                    throw any
+                } finally {
+                    build job: 'openshift-cluster-deprovision', parameters: [
+                        string(name: 'clusterName', value: "${clusterName}"),
+                        string(name: 'awsRegion', value: "${awsRegion}"),
+                        string(name: 'clusterDomainName', value: "${clusterDomainName}")]
+
+                    step([$class: 'Mailer', notifyEveryUnstableBuild: true, recipients: "${RECIPIENTS}", sendToIndividuals: true])
+                } // finally
+            } // node
+
+        }}} // timeout, ansiColor, timestamps

--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -95,6 +95,7 @@ jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/poc-install.ya
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/poc-testing-executor.yaml
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/poc-uninstall.yaml
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/psi-clean-uninstall.yaml
+jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/tower-clean-uninstall.yaml
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/recreate-pipelines.yaml
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/sso-user-create.yaml
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/w1-test-executor.yaml


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

This is a replacement of psi-clean-uninstall pipeline. Instead of using a long-running cluster backed by PSI it creates a cluster using Tower tooling and runs the uninstall there. It deprovisions the cluster afterward.

Part of this PR is not psi-clean-uninstall removal, will do once this is merged and we will be sure that it works better. I will create a PR for removal then.

Verification steps
jenkins-jobs --conf jenkins_jobs.ini test jobs/integr8ly/tower-clean-uninstall.yaml

The pipeline is already in Nightly tab, it was executed successfully yesterday (by me) and today (triggered automatically early morning)
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Nightly/job/tower-clean-uninstall/