### PR TITLE
INTLY-1812 Trigger github event monitor job on pr label change

### DIFF
--- a/jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('delorean-pipeline-library')
+@Library('delorean-pipeline-library') _
 def ghUtils = new org.integr8ly.GitHubUtils()
 
 import org.kohsuke.github.GHCommitState
@@ -53,7 +53,7 @@ def sourceChanges = false
 boolean runIntegrationTests = false
 boolean dryRun = params.dryRun
 String prUrl
-final String ghCommitStatusContext = 'delorean/ga/integration-tests'
+final String ghCommitStatusContext = 'delorean/integration-tests'
 String integrationTestsGHLabel = "integration tests"
 def jiraUserPass = params.jiraUserPass ?: 'integreatly-jira-bot'
 def productVersionVar = params.productVersionVar

--- a/jobs/delorean/misc/github-events/Jenkinsfile
+++ b/jobs/delorean/misc/github-events/Jenkinsfile
@@ -10,10 +10,7 @@ def ghUtils = new org.integr8ly.GitHubUtils()
 
 String githubEventStr = params.sqs_body
 String gitBranch = ""
-String installationGitUrl = ""
 String prUrl = ""
-boolean runBranchJob = false
-boolean runIntegrationTest = false
 
 String githubUserPassCredentialsID = "githubjenkins"
 final String ghCommitStatusContext = 'delorean/integration-tests'
@@ -27,75 +24,25 @@ node {
 
         if (ghEvent.eventType == "push") {
             gitBranch = ghEvent['ref'].tokenize('/').last()
-            runBranchJob = gitBranch.endsWith("-ga") || gitBranch.endsWith("-rc") || gitBranch.endsWith("-latest")
             currentBuild.description = "${currentBuild.description}\nevent: push\nbranch: ${gitBranch}"
         } 
 
         if (ghEvent.eventType == "pull_request") {
             def pullRequest = ghEvent.pull_request
             prUrl = pullRequest.html_url
-            def label = ghEvent.label.name
-            def ghRepo = ghEvent.repository
             gitBranch = pullRequest.head.ref
 
-            if (label == "integration tests") {
-                runIntegrationTest = true
-                installationGitUrl = ghRepo.clone_url
-            }
             currentBuild.description = "${currentBuild.description}\nevent: pull_request\nbranch: ${gitBranch}\npr: ${prUrl}"
         }
     }
 
     stage('Trigger branch job') {
-        when(runBranchJob) {
+        when(gitBranch.endsWith("-ga") || gitBranch.endsWith("-rc") || gitBranch.endsWith("-latest")) {
             println "Run branch job for ${productName}/${branchType}"
             def branchType = gitBranch.split("-").last()
             def productName = gitBranch.minus("-${branchType}")
             def jobName = "delorean-${productName}/${branchType}/branch"
             build job: jobName, wait: false
-        }
-    }
-
-    stage('Trigger integration test') {
-        when(runIntegrationTest) {
-            println "Run integration test with ${installationGitUrl} ${gitBranch}"
-            withCredentials([usernamePassword(
-                    credentialsId: githubUserPassCredentialsID,
-                    passwordVariable: 'GITHUB_PASSWORD',
-                    usernameVariable: 'GITHUB_USERNAME')]) {
-                final GitHub gitHub = new GitHubBuilder()
-                        .withOAuthToken(env.GITHUB_PASSWORD, env.GITHUB_USERNAME)
-                        .build()
-                ghUtils.ghUpdatePrCommitStatus(gitHub, prUrl, GHCommitState.PENDING, env.BUILD_URL, 'Pending', ghCommitStatusContext)
-            }
-            try {
-                def jobName = "openshift-cluster-integreatly-test"
-                def jobParams = [
-                    [$class: 'StringParameterValue', name: 'installationGitUrl', value: installationGitUrl],
-                    [$class: 'StringParameterValue', name: 'installationGitBranch', value: gitBranch]
-                ]
-                build job: jobName, parameters: jobParams
-            } catch (Exception e) {
-                withCredentials([usernamePassword(
-                        credentialsId: githubUserPassCredentialsID,
-                        passwordVariable: 'GITHUB_PASSWORD',
-                        usernameVariable: 'GITHUB_USERNAME')]) {
-                    final GitHub gitHub = new GitHubBuilder()
-                            .withOAuthToken(env.GITHUB_PASSWORD, env.GITHUB_USERNAME)
-                            .build()
-                    ghUtils.ghUpdatePrCommitStatus(gitHub, prUrl, GHCommitState.FAILURE, env.BUILD_URL, 'Failure', ghCommitStatusContext)
-                    error "Integration test failures, ${installationGitUrl}, ${gitBranch}, ${e}"
-                }
-            }
-            withCredentials([usernamePassword(
-                    credentialsId: githubUserPassCredentialsID,
-                    passwordVariable: 'GITHUB_PASSWORD',
-                    usernameVariable: 'GITHUB_USERNAME')]) {
-                final GitHub gitHub = new GitHubBuilder()
-                        .withOAuthToken(env.GITHUB_PASSWORD, env.GITHUB_USERNAME)
-                        .build()
-                ghUtils.ghUpdatePrCommitStatus(gitHub, prUrl, GHCommitState.SUCCESS, env.BUILD_URL, 'Success', ghCommitStatusContext)
-            }
         }
     }
 }

--- a/jobs/delorean/misc/github-events/Jenkinsfile
+++ b/jobs/delorean/misc/github-events/Jenkinsfile
@@ -1,25 +1,22 @@
 #!groovy
+@Library('delorean-pipeline-library') _
 
-//Helper methods, should eventually be moved to a shared library
-//https://github.com/comquent/imperative-when
-import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+import org.kohsuke.github.GHCommitState
+import org.kohsuke.github.GHPullRequest
+import org.kohsuke.github.GitHub
+import org.kohsuke.github.GitHubBuilder
 
-def when(boolean condition, body) {
-    def config = [:]
-    body.resolveStrategy = Closure.OWNER_FIRST
-    body.delegate = config
-
-    if (condition) {
-        body()
-    } else {
-        Utils.markStageSkippedForConditional(STAGE_NAME)
-    }
-}
-//Helpers
+def ghUtils = new org.integr8ly.GitHubUtils()
 
 String githubEventStr = params.sqs_body
 String gitBranch = ""
-boolean isGABranch = false
+String installationGitUrl = ""
+String prUrl = ""
+boolean runBranchJob = false
+boolean runIntegrationTest = false
+
+String githubUserPassCredentialsID = "githubjenkins"
+final String ghCommitStatusContext = 'delorean/integration-tests'
 
 currentBuild.description = "sqsMessageId: ${params.sqs_messageId}"
 
@@ -27,20 +24,78 @@ node {
     cleanWs()
     stage('Parse GitHub Event') {
         def ghEvent = readJSON text: githubEventStr
-        gitBranch = ghEvent['ref'].tokenize('/').last()
-        isGABranch = gitBranch.endsWith("-ga")
-        isRCBranch = gitBranch.endsWith("-rc")
-        isLatestBranch = gitBranch.endsWith("-latest")
-        currentBuild.description = "${currentBuild.description}\nbranch: ${gitBranch}"
+
+        if (ghEvent.eventType == "push") {
+            gitBranch = ghEvent['ref'].tokenize('/').last()
+            runBranchJob = gitBranch.endsWith("-ga") || gitBranch.endsWith("-rc") || gitBranch.endsWith("-latest")
+            currentBuild.description = "${currentBuild.description}\nevent: push\nbranch: ${gitBranch}"
+        } 
+
+        if (ghEvent.eventType == "pull_request") {
+            def pullRequest = ghEvent.pull_request
+            prUrl = pullRequest.html_url
+            def label = ghEvent.label.name
+            def ghRepo = ghEvent.repository
+            gitBranch = pullRequest.head.ref
+
+            if (label == "integration tests") {
+                runIntegrationTest = true
+                installationGitUrl = ghRepo.clone_url
+            }
+            currentBuild.description = "${currentBuild.description}\nevent: pull_request\nbranch: ${gitBranch}\npr: ${prUrl}"
+        }
     }
 
-    stage('Trigger ga branch job') {
-        when(isGABranch || isRCBranch || isLatestBranch) {
+    stage('Trigger branch job') {
+        when(runBranchJob) {
+            println "Run branch job for ${productName}/${branchType}"
             def branchType = gitBranch.split("-").last()
             def productName = gitBranch.minus("-${branchType}")
-            jobName = "delorean-${productName}/${branchType}/branch"
+            def jobName = "delorean-${productName}/${branchType}/branch"
             build job: jobName, wait: false
         }
     }
 
+    stage('Trigger integration test') {
+        when(runIntegrationTest) {
+            println "Run integration test with ${installationGitUrl} ${gitBranch}"
+            withCredentials([usernamePassword(
+                    credentialsId: githubUserPassCredentialsID,
+                    passwordVariable: 'GITHUB_PASSWORD',
+                    usernameVariable: 'GITHUB_USERNAME')]) {
+                final GitHub gitHub = new GitHubBuilder()
+                        .withOAuthToken(env.GITHUB_PASSWORD, env.GITHUB_USERNAME)
+                        .build()
+                ghUtils.ghUpdatePrCommitStatus(gitHub, prUrl, GHCommitState.PENDING, env.BUILD_URL, 'Pending', ghCommitStatusContext)
+            }
+            try {
+                def jobName = "openshift-cluster-integreatly-test"
+                def jobParams = [
+                    [$class: 'StringParameterValue', name: 'installationGitUrl', value: installationGitUrl],
+                    [$class: 'StringParameterValue', name: 'installationGitBranch', value: gitBranch]
+                ]
+                build job: jobName, parameters: jobParams
+            } catch (Exception e) {
+                withCredentials([usernamePassword(
+                        credentialsId: githubUserPassCredentialsID,
+                        passwordVariable: 'GITHUB_PASSWORD',
+                        usernameVariable: 'GITHUB_USERNAME')]) {
+                    final GitHub gitHub = new GitHubBuilder()
+                            .withOAuthToken(env.GITHUB_PASSWORD, env.GITHUB_USERNAME)
+                            .build()
+                    ghUtils.ghUpdatePrCommitStatus(gitHub, prUrl, GHCommitState.FAILURE, env.BUILD_URL, 'Failure', ghCommitStatusContext)
+                    error "Integration test failures, ${installationGitUrl}, ${gitBranch}, ${e}"
+                }
+            }
+            withCredentials([usernamePassword(
+                    credentialsId: githubUserPassCredentialsID,
+                    passwordVariable: 'GITHUB_PASSWORD',
+                    usernameVariable: 'GITHUB_USERNAME')]) {
+                final GitHub gitHub = new GitHubBuilder()
+                        .withOAuthToken(env.GITHUB_PASSWORD, env.GITHUB_USERNAME)
+                        .build()
+                ghUtils.ghUpdatePrCommitStatus(gitHub, prUrl, GHCommitState.SUCCESS, env.BUILD_URL, 'Success', ghCommitStatusContext)
+            }
+        }
+    }
 }

--- a/jobs/delorean/misc/github-events/github-events.yaml
+++ b/jobs/delorean/misc/github-events/github-events.yaml
@@ -9,7 +9,7 @@
         xml: |
           <io.relution.jenkins.awssqs.SQSTrigger plugin="aws-sqs@2.0.1">
             <spec></spec>
-            <queueUuid>b122060c-a518-4e46-939c-7ba8cbd8ce54</queueUuid>
+            <queueUuid>86ae1015-cb49-4bd9-99de-b264a9df328c</queueUuid>
           </io.relution.jenkins.awssqs.SQSTrigger>
     pipeline-scm:
       script-path: jobs/delorean/misc/github-events/Jenkinsfile


### PR DESCRIPTION
## What
The github webhook now sends events for pull requests. The changes included in this PR ensures the following:
- [x] The branch job should only get triggered on `push` events on the `-ga`, `-rc` and `-latest` branches.
- [x] Integration tests should run when the `integration tests` label gets added to an existing PR. This should also update the status of the PR.

## Verification Steps
- Verify that the github event job is triggered when changes are pushed to the installation repository
   - Ensure that push events to `-ga`, `-rc` or `-latest` branches runs the branch job.
   - All other push events to other branches should not run the branch job.
- Verify that the github event job is triggered when a label is added to a PR
   - Ensure that the integration tests are ran only when the `integration tests` label is added to the PR
   - Ensure that the PR status gets updated accordingly.