### PR TITLE
ensure all-tests-executor job does not run when dryRun is set to true

### DIFF
--- a/jobs/openshift/cluster/integreatly/test/Jenkinsfile
+++ b/jobs/openshift/cluster/integreatly/test/Jenkinsfile
@@ -122,11 +122,15 @@ pipeline {
             [$class: 'StringParameterValue', name: 'NUMBER_OF_USERS', value: '5']
           ]
 
-          buildStatus = build(job: 'all-tests-executor', propagate: false, parameters: jobParams).result
-          println "Build finished with ${buildStatus}"
-                            
-          if (buildStatus != 'SUCCESS') {
-            currentBuild.result = 'UNSTABLE'
+          if (params.dryRun) {
+            println "Would run the job 'all-tests-executor' with the following parameters:\n${jobParams}"
+          } else {
+            buildStatus = build(job: 'all-tests-executor', propagate: false, parameters: jobParams).result
+            println "Build finished with ${buildStatus}"
+                              
+            if (buildStatus != 'SUCCESS') {
+              currentBuild.result = 'UNSTABLE'
+            }
           }
         }
       }


### PR DESCRIPTION
## What
When `dryRun` is set to true, the cluster create/install workflow in Ansible Tower are not triggered. This only prints what this would do. We need to ensure that the tests are not ran when this parameter is true as it would always fail otherwise due to missing cluster and Integreatly install. 

- [x] Check if `dryRun` is set to true before triggering build for the job `all-tests-executor`.
