### PR TITLE
INTLY-2235: Configure global settings

### DIFF
--- a/scripts/playbooks/configure_jenkins.yaml
+++ b/scripts/playbooks/configure_jenkins.yaml
@@ -11,3 +11,6 @@
     - name: Add credentials
       include_role:
         name: add_credentials
+    - name: Configure Global Settings
+      include_role:
+        name: configure_global_settings

--- a/scripts/playbooks/configure_jenkins.yaml
+++ b/scripts/playbooks/configure_jenkins.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: localhost
+- hosts: all
   gather_facts: no
   tasks:
     - name: Preflight Checks

--- a/scripts/playbooks/roles/add_credentials/tasks/_create_credentials.yaml
+++ b/scripts/playbooks/roles/add_credentials/tasks/_create_credentials.yaml
@@ -32,6 +32,11 @@
     payload: "{{ lookup('template', 'user_pass_credential.txt.j2') }}"
   when: type == "user_pass"
 
+- name: Set payload for creating secret text credential
+  set_fact:
+    payload: "{{ lookup('template', 'secret_text_credential.txt.j2') }}"
+  when: type == "secret_text"
+
 - name: "Create {{ credential.key }}"
   uri:
     method: POST

--- a/scripts/playbooks/roles/add_credentials/tasks/_create_credentials.yaml
+++ b/scripts/playbooks/roles/add_credentials/tasks/_create_credentials.yaml
@@ -46,5 +46,5 @@
     force_basic_auth: yes
     validate_certs: no
     headers: "{{ req_headers | items2dict }}"
-    body: "{{ payload }}"
+    body: "{{ payload | replace('+', '%2B') }}"
     status_code: 200, 302

--- a/scripts/playbooks/roles/add_credentials/tasks/main.yaml
+++ b/scripts/playbooks/roles/add_credentials/tasks/main.yaml
@@ -37,3 +37,13 @@
   with_dict: "{{ jenkins_ssh_user_key_credentials }}"
   loop_control:
     loop_var: ssh_user_key_credential
+
+- name: Create secret text credentials
+  include_tasks: _create_credentials.yaml
+  vars:
+    req_headers: "{{ headers }}"
+    credential: "{{ secret_text_credential }}"
+    type: "secret_text"
+  with_dict: "{{ jenkins_secret_text_credentials }}"
+  loop_control:
+    loop_var: secret_text_credential

--- a/scripts/playbooks/roles/add_credentials/templates/secret_text_credential.txt.j2
+++ b/scripts/playbooks/roles/add_credentials/templates/secret_text_credential.txt.j2
@@ -1,0 +1,9 @@
+json={
+  "credentials": {
+    "scope": "GLOBAL",
+    "id": "{{ credential.value.id }}",
+    "secret": "{{ credential.value.secret }}",
+    "description": "{{ credential.value.description }}",
+    "$class": "org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl"
+  }
+}

--- a/scripts/playbooks/roles/configure_global_settings/defaults/main.yaml
+++ b/scripts/playbooks/roles/configure_global_settings/defaults/main.yaml
@@ -1,0 +1,5 @@
+---
+delorean_shared_library_name: "delorean-pipeline-library"
+delorean_shared_library_git_url: "https://github.com/integr8ly/delorean-pipeline-library.git"
+delorean_shared_library_version: "master"
+delorean_shared_library_load_implicit: false

--- a/scripts/playbooks/roles/configure_global_settings/files/configure_ansible_tower.groovy
+++ b/scripts/playbooks/roles/configure_global_settings/files/configure_ansible_tower.groovy
@@ -1,0 +1,19 @@
+import groovy.json.JsonSlurper
+import org.jenkinsci.plugins.ansible_tower.AnsibleTowerGlobalConfig
+import org.jenkinsci.plugins.ansible_tower.util.TowerInstallation
+
+def instance = Jenkins.getInstance()
+def tower = instance.getDescriptor(AnsibleTowerGlobalConfig.class)
+
+def towerInstallations = new JsonSlurper().parseText('${tower_installations}')
+
+List ansibleTowerInstallations = []
+towerInstallations.each{ towerInstallation ->
+  ansibleTowerInstallations.add(new TowerInstallation(towerInstallation.display_name, towerInstallation.url, towerInstallation.credentials_id, towerInstallation.trust_cert, towerInstallation.enable_debugging))
+}
+
+tower.setTowerInstallation(ansibleTowerInstallations)
+instance.save()
+
+
+

--- a/scripts/playbooks/roles/configure_global_settings/files/configure_aws_sqs_queue.groovy
+++ b/scripts/playbooks/roles/configure_global_settings/files/configure_aws_sqs_queue.groovy
@@ -1,0 +1,23 @@
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import io.relution.jenkins.awssqs.SQSTrigger
+import org.kohsuke.stapler.StaplerRequest
+import org.kohsuke.stapler.Stapler
+import net.sf.json.JSONObject
+import java.util.UUID
+
+def instance = Jenkins.getInstance()
+def sqs = instance.getDescriptor(SQSTrigger.class)
+
+StaplerRequest req = Stapler.getCurrentRequest();
+JSONObject json = new JSONObject()
+def sqsQueues = new JsonSlurper().parseText('${sqs_queues}')
+
+sqsQueues.each { sqsQueue ->
+  String uuid = UUID.randomUUID().toString()  
+  sqsQueue.uuid = uuid
+}
+json.accumulate("sqsQueues", sqsQueues)
+
+sqs.configure(req, json)
+instance.save()

--- a/scripts/playbooks/roles/configure_global_settings/files/configure_global_library.groovy
+++ b/scripts/playbooks/roles/configure_global_settings/files/configure_global_library.groovy
@@ -1,0 +1,34 @@
+import jenkins.plugins.git.GitSCMSource
+import jenkins.plugins.git.traits.BranchDiscoveryTrait
+import jenkins.plugins.git.traits.RefSpecsSCMSourceTrait
+import jenkins.plugins.git.traits.RefSpecsSCMSourceTrait.RefSpecTemplate
+import org.jenkinsci.plugins.workflow.libs.GlobalLibraries
+import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration
+import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever
+
+def libraryName = "${library_name}"
+def gitUrl = "${gitUrl}"
+def loadImplicit = "${load_implicit}".toBoolean()
+def sshCredentialsId = "jenkinsgithub"
+def version = "${default_version}"
+
+def instance = Jenkins.getInstance()
+def descriptor = instance.getDescriptor(GlobalLibraries.class)
+
+def templates = [new RefSpecTemplate("+refs/heads/*:refs/remotes/@{remote}/*"), new RefSpecTemplate("+refs/pull/*/head:refs/remotes/@{remote}/pr/*")]
+List sourceTraits = []
+sourceTraits.add(new BranchDiscoveryTrait())
+sourceTraits.add(new RefSpecsSCMSourceTrait(templates))
+
+GitSCMSource source = new GitSCMSource(gitUrl)
+source.setCredentialsId(sshCredentialsId)
+source.setTraits(sourceTraits)
+
+LibraryConfiguration library = new LibraryConfiguration(libraryName, new SCMSourceRetriever(source))
+library.setDefaultVersion(version)
+library.setImplicit(loadImplicit)
+descriptor.get().setLibraries([library])
+
+
+
+

--- a/scripts/playbooks/roles/configure_global_settings/tasks/main.yaml
+++ b/scripts/playbooks/roles/configure_global_settings/tasks/main.yaml
@@ -14,3 +14,15 @@
       load_implicit: "{{ delorean_shared_library_load_implicit }}"
   register: configure_global_library
   changed_when: not configure_global_library.failed
+
+- name: Configure Ansible Tower settings
+  jenkins_script:
+    script: "{{ lookup('file', 'configure_ansible_tower.groovy') }}"
+    url: "{{ jenkins_url }}"
+    user: "{{ jenkins_admin_username }}"
+    password: "{{ jenkins_admin_password }}"
+    validate_certs: no
+    args:
+      tower_installations: "{{ ansible_tower_installations | to_json }}"
+  register: configure_ansible_tower
+  changed_when: not configure_ansible_tower.failed

--- a/scripts/playbooks/roles/configure_global_settings/tasks/main.yaml
+++ b/scripts/playbooks/roles/configure_global_settings/tasks/main.yaml
@@ -1,0 +1,16 @@
+---
+
+- name: Configure Delorean shared pipline library
+  jenkins_script:
+    script: "{{ lookup('file', 'configure_global_library.groovy') }}"
+    url: "{{ jenkins_url }}"
+    user: "{{ jenkins_admin_username }}"
+    password: "{{ jenkins_admin_password }}"
+    validate_certs: no
+    args:
+      library_name: "delorean-pipeline-library"
+      gitUrl: "https://github.com/integr8ly/delorean-pipeline-library.git"
+      default_version: "master"
+      load_implicit: false
+  register: global_library_status
+  changed_when: not global_library_status.failed

--- a/scripts/playbooks/roles/configure_global_settings/tasks/main.yaml
+++ b/scripts/playbooks/roles/configure_global_settings/tasks/main.yaml
@@ -26,3 +26,18 @@
       tower_installations: "{{ ansible_tower_installations | to_json }}"
   register: configure_ansible_tower
   changed_when: not configure_ansible_tower.failed
+
+- set_fact:
+    queues: "{{ aws_sqs_queues }}"
+
+- name: Configure Amazon SQS Queue
+  jenkins_script:
+    script: "{{ lookup('file', 'configure_aws_sqs_queue.groovy') }}"
+    url: "{{ jenkins_url }}"
+    user: "{{ jenkins_admin_username }}"
+    password: "{{ jenkins_admin_password }}"
+    validate_certs: no
+    args:
+      sqs_queues: "{{ queues | to_json}}"
+  register: configure_aws_sqs
+  changed_when: not configure_aws_sqs.failed

--- a/scripts/playbooks/roles/configure_global_settings/tasks/main.yaml
+++ b/scripts/playbooks/roles/configure_global_settings/tasks/main.yaml
@@ -8,9 +8,9 @@
     password: "{{ jenkins_admin_password }}"
     validate_certs: no
     args:
-      library_name: "delorean-pipeline-library"
-      gitUrl: "https://github.com/integr8ly/delorean-pipeline-library.git"
-      default_version: "master"
-      load_implicit: false
-  register: global_library_status
-  changed_when: not global_library_status.failed
+      library_name: "{{ delorean_shared_library_name }}"
+      gitUrl: "{{ delorean_shared_library_git_url }}"
+      default_version: "{{ delorean_shared_library_version }}"
+      load_implicit: "{{ delorean_shared_library_load_implicit }}"
+  register: configure_global_library
+  changed_when: not configure_global_library.failed

--- a/scripts/plugins.txt
+++ b/scripts/plugins.txt
@@ -10,6 +10,7 @@ http_request:1.8.22
 groovy:2.0 
 gitlab-plugin:1.5.9
 gitlab-hook:1.4.2
+git:3.9.1
 ghprb:1.42.0
 extended-choice-parameter:0.76
 delivery-pipeline-plugin:1.2.0


### PR DESCRIPTION
## What
The following changes adds the ability to automatically configure the global settings for Ansible Tower, AWS SQS and the Delorean shared pipeline library. This also adds the ability to create secret text credentials which is required by AWS SQS. Addition of `git` to the list of plugins is required by the configuration of the Delorean shared pipeline library.

- [x] Add task to configure the delorean shared pipeline library
- [x] Add task to configure the Ansible Tower settings
- [x] Add task to configure the AWS SQS Queue settings
- [x] Add task to create secret text credentials

**NOTE**: Also added a fix to encode `+` symbols

## Verification
Run the `configure_jenkins` script. 
- Ensure all resources are created successfully
- Ensure Ansible Tower was configured correctly
- Ensure the global libraries includes the Delorean shared pipeline library
- Ensure AWS SQS Queue was configured correctly