### PR TITLE
add task to configure delorean jobs

### DIFF
--- a/docs/delorean/configuring-jenkins.md
+++ b/docs/delorean/configuring-jenkins.md
@@ -7,8 +7,9 @@
     - [2.2 Host Vars](#host-vars)
     - [2.3 Credentials and Global Settings](#credentials-and-global-settings)
   - [3. Running the Script](#running-the-script)
-    - [3.1 Plugins Installation](#plugins-installation)
-    - [3.2 Potential Issues During Configuraiton](#potential-issues-during-configuration)
+    - [3.1 Configuring the Delorean Jobs](#configuring-the-delorean-jobs)
+    - [3.2 Plugins Installation](#plugins-installation)
+    - [3.3 Potential Issues During Configuraiton](#potential-issues-during-configuration)
   - [4. Node Configuration](#node-configuration)
     - [4.1 Tools](#tools)
     - [4.2 Red Hat Registry CA](#red-hat-registry-ca)
@@ -57,6 +58,19 @@ Configure the `inventories/group_vars/all/credentials.yaml` file. This contains 
 ## Running the script
 ```sh
 ansible-playbook -i inventories/hosts playbooks/configure_jenkins.yaml
+```
+
+### Configuring the Delorean Jobs
+The Delorean jobs are not configured by the script by default. If you choose to configure this, set the variable `configure_delorean_jobs` to `true` as a parameter when running the script.
+
+```sh
+ansible-playbook -i inventories/hosts playbooks/configure_jenkins.yaml -e configure_delorean_jobs=true
+```
+
+A playbook is available to run this task separately
+
+```
+ansible-playbook -i inventories/hosts playbooks/configure_delorean_jobs.yaml
 ```
 
 ### Plugins Installation
@@ -173,25 +187,3 @@ Ensure the `jenkins` user has a `.ssh` directory with `authorized_keys` availabl
 
 #### Docker
 Ensure the user `jenkins` gets added to the group `docker`
-
-## Delorean Jobs Configuration
-
-Create a `jenkins.ini` file with the following configuration:
-```
-[job_builder]
-ignore_cache=True
-keep_descriptions=False
-include_path=.:scripts:~/git/
-recursive=False
-exclude=.*:manual:./development
-allow_duplicates=False
-
-[jenkins]
-user=<jenkins-userid>
-password=<jenkins-password-or-token>
-url=<jenkins-url>
-query_plugins_info=False
-```
-
-Run:
-./scripts/configure_jenkins.sh jenkins.ini

--- a/scripts/playbooks/configure_delorean_jobs.yaml
+++ b/scripts/playbooks/configure_delorean_jobs.yaml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  gather_facts: no
+  tasks:
+    - name: Configure Delorean Jobs
+      include_role:
+        name: configure_delorean_jobs

--- a/scripts/playbooks/configure_jenkins.yaml
+++ b/scripts/playbooks/configure_jenkins.yaml
@@ -14,3 +14,7 @@
     - name: Configure Global Settings
       include_role:
         name: configure_global_settings
+    - name: Configure Delorean Jobs
+      include_role:
+        name: configure_delorean_jobs
+      when: configure_delorean_jobs is defined and configure_delorean_jobs == true

--- a/scripts/playbooks/configure_jenkins.yaml
+++ b/scripts/playbooks/configure_jenkins.yaml
@@ -17,4 +17,4 @@
     - name: Configure Delorean Jobs
       include_role:
         name: configure_delorean_jobs
-      when: configure_delorean_jobs is defined and configure_delorean_jobs == true
+      when: configure_delorean_jobs is defined and configure_delorean_jobs == 'true'

--- a/scripts/playbooks/roles/configure_delorean_jobs/tasks/main.yaml
+++ b/scripts/playbooks/roles/configure_delorean_jobs/tasks/main.yaml
@@ -1,0 +1,14 @@
+---
+- set_fact:
+    base_dir: "{{ playbook_dir | dirname}}"
+
+# Create config file for configuring the delorean jobs
+- name: Generate jenkins config template
+  template:
+    src: "jenkins-config.ini.j2"
+    dest: "{{base_dir}}/jenkins-config.ini"
+
+- name: "Configure Delorean Jobs"
+  shell: "sh ./scripts/configure_jenkins.sh ./scripts/jenkins-config.ini"
+  args:
+    chdir: "{{ base_dir }}/../"

--- a/scripts/playbooks/roles/configure_delorean_jobs/templates/jenkins-config.ini.j2
+++ b/scripts/playbooks/roles/configure_delorean_jobs/templates/jenkins-config.ini.j2
@@ -1,0 +1,13 @@
+[job_builder]
+ignore_cache=True
+keep_descriptions=False
+include_path=.:scripts:~/git/
+recursive=False
+exclude=.*:manual:./development
+allow_duplicates=False
+
+[jenkins]
+url = {{ jenkins_url }}
+user = {{ jenkins_admin_username }}
+password = {{ jenkins_admin_password }}
+query_plugins_info=False


### PR DESCRIPTION
## What
- [x] Create a role for configuring delorean jobs
   - This should create a jenkins-config.ini file with Jenkins configuration
   - This should call the `scripts/configure_jenkins.sh` script to create the delorean jobs in the target Jenkins instance.
- [x] Include this role in the `configure_jenkins.yaml` playbook
- [x] Create an additional playbook to configure the delorean jobs only

The playbook is configured to skip the creation of delorean  jobs by default. In order to create the delorean jobs, the variable `configure_delorean_jobs` must be set to true.

Example command: 
```
ansible-playbook -i inventories/hosts playbooks/configure_jenkins -e configure_delorean_jobs=true
```
