### PR TITLE
separate the credentials and global settings config

### DIFF
--- a/docs/delorean/configuring-jenkins.md
+++ b/docs/delorean/configuring-jenkins.md
@@ -5,7 +5,7 @@
   - [2. Configuring the inventory](#configuring-the-inventory)
     - [2.1 Host File](#host-file)
     - [2.2 Host Vars](#host-vars)
-    - [2.3 Credentials and Global Settings](#credentials-and-global-settings)
+    - [2.3 Group Vars](#group-vars)
   - [3. Running the Script](#running-the-script)
     - [3.1 Configuring the Delorean Jobs](#configuring-the-delorean-jobs)
     - [3.2 Plugins Installation](#plugins-installation)
@@ -52,8 +52,12 @@ jenkins.example.com
 
 The host `jenkins.example.com` should have a host_vars with the filename `host_vars/jenkins.example.com.yaml`
 
-### Credentials and Global Settings
-Configure the `inventories/group_vars/all/credentials.yaml` file. This contains all the configuration for global settings and credentials required by the Delorean jobs.
+### Group Vars
+#### Credentials
+Configure the [credentials.yaml](../../scripts/inventories/group_vars/all/credentials.yaml) file. This contains all the configuration for credentials required by the Delorean jobs.
+
+#### Global Settings
+Configure the [global-settings.yaml](../../scripts/inventories/group_vars/all/global-settings.yaml) file. This contains all the configuration for the global settings required by the Delorean jobs.
 
 ## Running the script
 ```sh

--- a/scripts/inventories/group_vars/all/credentials.yaml
+++ b/scripts/inventories/group_vars/all/credentials.yaml
@@ -1,19 +1,4 @@
 ---
-# Ansible Tower Configuration
-ansible_tower_installations:
-  - display_name: ""                          # Ansible Tower display name
-    url: ""                                   # Ansible Tower url i.e. https://tower.example.com/
-    credentials_id: "tower-admin-user"        # Credential ID where the tower admin username/password is stored
-    trust_cert: false                         # Set to true to force Jenkins to ignore the cert presented by Ansible Tower
-    enable_debugging: false                   # Set to true to enable debugging messages to be printed in the Jenkins log
-
-# AWS SQS Configuration
-aws_sqs_queues:
-  - nameOrUrl: ""                             # Name or url of your message queue in AWS SQS
-    credentialsId: "aws-jenkins-integreatly"  # Credential ID where the AWS client ID/token is stored
-    waitTimeSeconds: "20"                     # Time to wait for a message to arrive in the queue (in seconds)
-    maxNumberOfMessages: "1"                  # Maximum number of messages to receive per request
-
 # User/Password Credentials
 jenkins_user_pass_credentials:
   - tower-admin-user:

--- a/scripts/inventories/group_vars/all/global-settings.yaml
+++ b/scripts/inventories/group_vars/all/global-settings.yaml
@@ -1,0 +1,15 @@
+---
+# Ansible Tower Configuration
+ansible_tower_installations:
+  - display_name: ""                          # Ansible Tower display name
+    url: ""                                   # Ansible Tower url i.e. https://tower.example.com/
+    credentials_id: "tower-admin-user"        # Credential ID where the tower admin username/password is stored
+    trust_cert: false                         # Set to true to force Jenkins to ignore the cert presented by Ansible Tower
+    enable_debugging: false                   # Set to true to enable debugging messages to be printed in the Jenkins log
+
+# AWS SQS Configuration
+aws_sqs_queues:
+  - nameOrUrl: ""                             # Name or url of your message queue in AWS SQS
+    credentialsId: "aws-jenkins-integreatly"  # Credential ID where the AWS client ID/token is stored
+    waitTimeSeconds: "20"                     # Time to wait for a message to arrive in the queue (in seconds)
+    maxNumberOfMessages: "1"                  # Maximum number of messages to receive per request


### PR DESCRIPTION
## What
- [x] Remove the global settings configuration from the `credentials.yaml` file
- [x] Create a `global-settings.yaml` file in the group_vars. This should contain all of the global settings configuration required by the script.
- [x] Update the documentation according to the changes above

