### PR TITLE
add delorean and support section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Continuous Integration / Continuous Delivery related bits
 ## Jenkins Job Builder
 Job definitions are stored in form of templates for [Jenkins Job Builder](https://docs.openstack.org/infra/jenkins-job-builder/) (JJB). 
 
-## Installation
+### Installation
 
-### Linux
+#### Linux
 Go to https://docs.openstack.org/infra/jenkins-job-builder/ and follow the instructions.
 
-### Mac
+#### Mac
 Install jjb using Brew:
 
 `brew install jenkins-job-builder`
@@ -51,7 +51,7 @@ jenkins-jobs --conf /path/to/your/jenkins_jobs.ini update /path/to/your/template
 ./scripts/configure_jenkins /path/to/your/jenkins_jobs.ini
 ```
 
-## Troubleshooting
+### Troubleshooting
 To prevent from getting SSL: CERTIFICATE_VERIFY_FAILED when running jenkins-jobs commands:
 `ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain`
 
@@ -60,3 +60,13 @@ execute the following command in the terminal:
 ```
 export PYTHONHTTPSVERIFY=0
 ```
+
+## Delorean
+
+All documentation related to Delorean are located [here](docs/README.md)
+
+### Support
+
+Please open a Github issue in this repository for any bugs or problems you encounter.
+
+If you encounter any issues with the Ansible Tower tooling, please open a Github issue [here](https://github.com/integr8ly/ansible-tower-configuration).

--- a/README.md
+++ b/README.md
@@ -1,20 +1,34 @@
 # ci-cd
 Continuous Integration / Continuous Delivery related bits
 
-## Jenkins Job Builder
+## Table of contents
+- [1. Jenkins Job Builder](#1-jenkins-job-builder)
+  - [1.1 Installation](#11-installation)
+    - [1.1.1 Linux](#111-linux)
+    - [1.1.2 Mac](#112-mac)
+  - [1.2 Configuration of JJB](#12-configuration-of-jjb)
+  - [1.3 Test your template](#13-test-your-template)
+  - [1.4 Update your job](#14-update-your-job)
+  - [1.5 Generate inline script jobs](#15-generate-inline-script-jobs)
+  - [1.6 Configure all jobs and views](#16-configure-all-jobs-and-views)
+  - [1.7 Troubleshooting](#17-troubleshooting)
+- [2. Delorean](#2-delorean)
+  - [2.1 Support](#21-support)
+
+## 1. Jenkins Job Builder
 Job definitions are stored in form of templates for [Jenkins Job Builder](https://docs.openstack.org/infra/jenkins-job-builder/) (JJB). 
 
-### Installation
+### 1.1 Installation
 
-#### Linux
+#### 1.1.1 Linux
 Go to https://docs.openstack.org/infra/jenkins-job-builder/ and follow the instructions.
 
-#### Mac
+#### 1.1.2 Mac
 Install jjb using Brew:
 
 `brew install jenkins-job-builder`
 
-### Configuration of JJB
+### 1.2 Configuration of JJB
 Create `jenkins_job.ini` file containing
 ```
 [job_builder]
@@ -31,27 +45,27 @@ url=<YOUR_JENKINS_INSTANCE_URL>
 query_plugins_info=False
 ```
 
-### Test your template
+### 1.3 Test your template
 ```
 jenkins-jobs --conf /path/to/your/jenkins_jobs.ini test /path/to/your/template.yaml
 ```
 
-### Update your job
+### 1.4 Update your job
 ```
 jenkins-jobs --conf /path/to/your/jenkins_jobs.ini update /path/to/your/template.yaml
 ```
 
-### Generate inline script jobs
+### 1.5 Generate inline script jobs
 ```
 ./scripts/generate_inline_script_pipeline_job -j /path/to/your/template.yaml -o /path/to/your/generated/jobs
 ```
 
-### Configure all jobs and views
+### 1.6 Configure all jobs and views
 ```
 ./scripts/configure_jenkins /path/to/your/jenkins_jobs.ini
 ```
 
-### Troubleshooting
+### 1.7 Troubleshooting
 To prevent from getting SSL: CERTIFICATE_VERIFY_FAILED when running jenkins-jobs commands:
 `ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain`
 
@@ -61,11 +75,11 @@ execute the following command in the terminal:
 export PYTHONHTTPSVERIFY=0
 ```
 
-## Delorean
+## 2. Delorean
 
 All documentation related to Delorean are located [here](docs/README.md)
 
-### Support
+### 2.1 Support
 
 Please open a Github issue in this repository for any bugs or problems you encounter.
 


### PR DESCRIPTION
## What
- [x] Add a Delorean section in the main README
   - This should link to the Delorean documentation in the `docs/` folder
- [x] Add a Support section under the Delorean heading