### PR TITLE
Update templateDir param for 3scale RC job.

### DIFF
--- a/jobs/delorean/3scale/rc/discovery.yaml
+++ b/jobs/delorean/3scale/rc/discovery.yaml
@@ -34,7 +34,7 @@
           read-only: true
       - string:
           name: 'templatesDir'
-          default: 'pkg/3scale/amp/auto-generated-templates/productized_templates/amp'
+          default: 'pkg/3scale/amp/auto-generated-templates/amp'
           description: '[REQUIRED] directory where openshift templates are located'
           read-only: true
       - string:


### PR DESCRIPTION
## What

Not really sure why, but the path to where the templates are located changed between ER1 and ER2 https://github.com/3scale/3scale-operator/blob/3scale-2.6.0-ER2/pkg/3scale/amp/auto-generated-templates/amp/amp.yml vs https://github.com/3scale/3scale-operator/blob/3scale-2.6.0-ER1/pkg/3scale/amp/auto-generated-templates/productized_templates/amp/amp.yml

Updating to work with the latest pre release (3scale-2.6.0-ER2), but will need to keep an eye on it to check it wasn't some weird once off.
