### PR TITLE
Removal of EVALS_PASSWORD param

### DIFF
--- a/jobs/integr8ly/after-first-login-tests.yaml
+++ b/jobs/integr8ly/after-first-login-tests.yaml
@@ -20,15 +20,22 @@
       - string:
           name: EVALS_USERNAME
           default: 'evals11@example.com'
-          description: 'Evals account email address for checking created namespaces.'    
+          description: 'Evals account email address for checking created namespaces.'
       - string:
-          name: EVALS_PASSWORD
+          name: ADMIN_USERNAME
+          default: 'admin@example.com'
+          description: 'Username for Tutorial Web App log in'
+      - string:
+          name: ADMIN_PASSWORD
           default: 'Password1'
-          description: 'Evals user password'    
+          description: 'Password for the Tutorial Web App log in'
+      - string:
+          name: NAMESPACE_PREFIX
+          description: "Value used to prefix the names of the namespaces created during Integr8ly installation"
       - string:
           name: TIMEOUT_THRESHOLD
           default: '1'
-          description: 'optionally increase timeout values. If you provide value 2 it means it will be sleeping/waiting two times longer'      
+          description: 'optionally increase timeout values. If you provide value 2 it means it will be sleeping/waiting two times longer'
     dsl: |
         timeout(60) { ansiColor('gnome-terminal') { timestamps {
             node('cirhos_rhel7') {
@@ -56,13 +63,13 @@
                             publishTestResults = false
                         } else if(output.contains('There were test failures')) {
                             currentBuild.result = 'UNSTABLE'
-                        }              
+                        }
                     }
                 }
                 stage('Publish test results') {
                     if (publishTestResults) {
                         dir('test-suites/backend-testsuite/reports/') {
-                            archiveArtifacts 'after-first-login.xml'                  
+                            archiveArtifacts 'after-first-login.xml'
                             junit allowEmptyResults:true, testResults: 'after-first-login.xml'
                         } 
                     } else {

--- a/jobs/integr8ly/all-tests-executor.yaml
+++ b/jobs/integr8ly/all-tests-executor.yaml
@@ -25,10 +25,6 @@
           default: 'evals11@example.com'
           description: 'Evals account email address for checking created namespaces.'    
       - string:
-          name: EVALS_PASSWORD
-          default: 'Password1'
-          description: 'Evals user password'
-      - string:
           name: ADMIN_USERNAME
           default: 'admin@example.com'
           description: 'Admin sername to login to Integreatly cluster.'
@@ -83,7 +79,6 @@
             string(name: 'BRANCH', value: "${BRANCH}"),
             string(name: 'CLUSTER_URL', value: "${CLUSTER_URL}"),
             string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
-            string(name: 'EVALS_PASSWORD', value: "${EVALS_PASSWORD}"),
             string(name: 'ADMIN_USERNAME', value: "${ADMIN_USERNAME}"),
             string(name: 'ADMIN_PASSWORD', value: "${ADMIN_PASSWORD}"),
             string(name: 'CUSTOMER_ADMIN_USERNAME', value: "${CUSTOMER_ADMIN_USERNAME}"),

--- a/jobs/integr8ly/amq-online-address-creation-test.yaml
+++ b/jobs/integr8ly/amq-online-address-creation-test.yaml
@@ -28,10 +28,6 @@
       - string:
           name: EVALS_USERNAME
           description: 'evals username used to create the address'
-      - string:
-          name: EVALS_PASSWORD
-          default: 'Password1'
-          description: 'Evals user password'
       - bool:
           name: CLEAN_RESOURCES
           default: true
@@ -73,7 +69,7 @@
                 stage('Publish test results') {
                     if(publishTestResults) {
                         dir('test-suites/backend-testsuite/reports/') {
-                            archiveArtifacts 'address-create.xml'                  
+                            archiveArtifacts 'address-create.xml'
                             junit allowEmptyResults:true, testResults: 'address-create.xml'
                         }
                     } else {

--- a/jobs/integr8ly/browser-based-single-test.yaml
+++ b/jobs/integr8ly/browser-based-single-test.yaml
@@ -33,9 +33,8 @@
           default: 'evals11@example.com'
           description: 'Evals account email address used to access the available consoles'
       - string:
-          name: EVALS_PASSWORD
-          default: 'Password1'
-          description: 'Evals user password'
+          name: NAMESPACE_PREFIX
+          description: "Value used to prefix the names of the namespaces created during Integr8ly installation"
       - string:
           name: TEST_TO_RUN
           default: 

--- a/jobs/integr8ly/browser-based-testsuite-pipeline.yaml
+++ b/jobs/integr8ly/browser-based-testsuite-pipeline.yaml
@@ -33,9 +33,8 @@
           default: 'evals11@example.com'
           description: 'Evals account email address used to access the available consoles'
       - string:
-          name: EVALS_PASSWORD
-          default: 'Password1'
-          description: 'Evals user password'
+          name: NAMESPACE_PREFIX
+          description: "Value used to prefix the names of the namespaces created during Integr8ly installation"
       - string:
           name: TIMEOUT_THRESHOLD
           default: '1'
@@ -74,7 +73,7 @@
 
                 stage('Publish test results') {
                     dir('integreatly-qe/test-suites/ui-testsuite/reports') {
-                        archiveArtifacts '**/*.xml'                  
+                        archiveArtifacts '**/*.xml'
                         junit allowEmptyResults:true, testResults: '**/*.xml'
                     }
                 }

--- a/jobs/integr8ly/codeready-test.yaml
+++ b/jobs/integr8ly/codeready-test.yaml
@@ -31,10 +31,6 @@
           name: EVALS_USERNAME
           default: 'evals11@example.com'
           description: 'Evals account email address used to access the available consoles.'
-      - string:
-          name: EVALS_PASSWORD
-          default: 'Password1'
-          description: 'Evals user password'
       - bool:
           name: CLEAN_RESOURCES
           default: true

--- a/jobs/integr8ly/fuse-test.yaml
+++ b/jobs/integr8ly/fuse-test.yaml
@@ -31,10 +31,6 @@
           name: EVALS_USERNAME
           default: 'evals11@example.com'
           description: 'Evals account email address used to access the available consoles. This test expects that this user started the Walkthrough 1A!!'
-      - string:
-          name: EVALS_PASSWORD
-          default: 'Password1'
-          description: 'Evals user password'
       - bool:
           name: CLEAN_RESOURCES
           default: true

--- a/jobs/integr8ly/launcher-test.yaml
+++ b/jobs/integr8ly/launcher-test.yaml
@@ -28,10 +28,6 @@
           name: EVALS_USERNAME
           default: 'evals11@example.com'
           description: 'Evals user name'
-      - string:
-          name: EVALS_PASSWORD
-          default: 'Password1'
-          description: 'Evals user password'
       - bool:
           name: CLEAN_RESOURCES
           default: true
@@ -73,7 +69,7 @@
                 stage('Publish test results') {
                     if(publishTestResults) {
                         dir('test-suites/backend-testsuite/reports/') {
-                            archiveArtifacts 'booster-creation.xml'                  
+                            archiveArtifacts 'booster-creation.xml'
                             junit allowEmptyResults:true, testResults: 'booster-creation.xml'
                         }
                     } else {

--- a/jobs/integr8ly/pds-testing-executor.yaml
+++ b/jobs/integr8ly/pds-testing-executor.yaml
@@ -47,11 +47,7 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
         - string:
             name: EVALS_USERNAME
             default: 'evals11@example.com'
-            description: 'Evals account email address used in test suites.'    
-        - string:
-            name: EVALS_PASSWORD
-            default: 'Password1'
-            description: 'Evals user password used in test suites'
+            description: 'Evals account email address used in test suites.'
         - string:
             name: ADMIN_USERNAME
             default: 'admin@example.com'
@@ -205,7 +201,6 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                 string(name: 'BRANCH', value: "${TEST_SUITES_BRANCH}"),
                 string(name: 'CLUSTER_URL', value: "https://master.${YOURCITY}.openshiftworkshop.com"),
                 string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
-                string(name: 'EVALS_PASSWORD', value: "${EVALS_PASSWORD}"),
                 string(name: 'ADMIN_USERNAME', value: "${ADMIN_USERNAME}"),
                 string(name: 'ADMIN_PASSWORD', value: "${ADMIN_PASSWORD}"),
                 string(name: 'CUSTOMER_ADMIN_USERNAME', value: "${CUSTOMER_ADMIN_USERNAME}"),

--- a/jobs/integr8ly/pds-testing-nightly-no-patch-trigger.yaml
+++ b/jobs/integr8ly/pds-testing-nightly-no-patch-trigger.yaml
@@ -23,7 +23,6 @@
             TEST_SUITES_REPOSITORY=https://gitlab.cee.redhat.com/integreatly-qe/integreatly-qe.git
             TEST_SUITES_BRANCH=master
             EVALS_USERNAME=evals11@example.com
-            EVALS_PASSWORD=Password1
             ADMIN_USERNAME=admin@example.com
             ADMIN_PASSWORD=Password1
             CUSTOMER_ADMIN_PASSWORD=customer-admin@example.com
@@ -49,7 +48,6 @@
                         string(name: 'TEST_SUITES_REPOSITORY', value: "${TEST_SUITES_REPOSITORY}"),
                         string(name: 'TEST_SUITES_BRANCH', value: "${TEST_SUITES_BRANCH}"),
                         string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
-                        string(name: 'EVALS_PASSWORD', value: "${EVALS_PASSWORD}"),
                         string(name: 'ADMIN_USERNAME', value: "${ADMIN_USERNAME}"),
                         string(name: 'ADMIN_PASSWORD', value: "${ADMIN_PASSWORD}"),
                         string(name: 'CUSTOMER_ADMIN_USERNAME', value: "${CUSTOMER_ADMIN_USERNAME}"),

--- a/jobs/integr8ly/pds-testing-nightly-trigger.yaml
+++ b/jobs/integr8ly/pds-testing-nightly-trigger.yaml
@@ -23,7 +23,6 @@
             TEST_SUITES_REPOSITORY=https://gitlab.cee.redhat.com/integreatly-qe/integreatly-qe.git
             TEST_SUITES_BRANCH=development
             EVALS_USERNAME=evals11@example.com
-            EVALS_PASSWORD=Password1
             ADMIN_USERNAME=admin@example.com
             ADMIN_PASSWORD=Password1
             CUSTOMER_ADMIN_PASSWORD=customer-admin@example.com
@@ -49,7 +48,6 @@
                         string(name: 'TEST_SUITES_REPOSITORY', value: "${TEST_SUITES_REPOSITORY}"),
                         string(name: 'TEST_SUITES_BRANCH', value: "${TEST_SUITES_BRANCH}"),
                         string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
-                        string(name: 'EVALS_PASSWORD', value: "${EVALS_PASSWORD}"),
                         string(name: 'ADMIN_USERNAME', value: "${ADMIN_USERNAME}"),
                         string(name: 'ADMIN_PASSWORD', value: "${ADMIN_PASSWORD}"),
                         string(name: 'CUSTOMER_ADMIN_USERNAME', value: "${CUSTOMER_ADMIN_USERNAME}"),

--- a/jobs/integr8ly/poc-testing-executor.yaml
+++ b/jobs/integr8ly/poc-testing-executor.yaml
@@ -44,11 +44,7 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
         - string:
             name: EVALS_USERNAME
             default: 'evals11@example.com'
-            description: 'Evals account email address used in test suites.'    
-        - string:
-            name: EVALS_PASSWORD
-            default: 'Password1'
-            description: 'Evals user password used in test suites'
+            description: 'Evals account email address used in test suites.'
         - string:
             name: CUSTOMER_ADMIN_USERNAME
             default: 'customer-admin@example.com'
@@ -106,7 +102,7 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             choices:
               - full
               - install + tests
-              - uninstall + install + tests    
+              - uninstall + install + tests
     dsl: |
         def err = null
         try {
@@ -230,7 +226,6 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                 string(name: 'BRANCH', value: "${TEST_SUITES_BRANCH}"),
                 string(name: 'CLUSTER_URL', value: "https://${CLUSTER_HOSTNAME}"),
                 string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
-                string(name: 'EVALS_PASSWORD', value: "${EVALS_PASSWORD}"),
                 string(name: 'ADMIN_USERNAME', value: "${OC_USER}"),
                 string(name: 'ADMIN_PASSWORD', value: "${OC_PASSWORD}"),
                 string(name: 'CUSTOMER_ADMIN_USERNAME', value: "${CUSTOMER_ADMIN_USERNAME}"),

--- a/jobs/integr8ly/poc-testing-nightly-no-patch-trigger.yaml
+++ b/jobs/integr8ly/poc-testing-nightly-no-patch-trigger.yaml
@@ -27,7 +27,6 @@
             OC_USER=integreatly
             OC_PASSWORD=Password1
             EVALS_USERNAME=evals11@example.com
-            EVALS_PASSWORD=Password1
             CUSTOMER_ADMIN_PASSWORD=customer-admin@example.com
             CUSTOMER_ADMIN_PASSWORD=Password1
             CLEAN_RESOURCES=true
@@ -56,7 +55,6 @@
                         string(name: 'OC_USER', value: "${OC_USER}"),
                         string(name: 'OC_PASSWORD', value: "${OC_PASSWORD}"),
                         string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
-                        string(name: 'EVALS_PASSWORD', value: "${EVALS_PASSWORD}"),
                         string(name: 'CUSTOMER_ADMIN_USERNAME', value: "${CUSTOMER_ADMIN_USERNAME}"),
                         string(name: 'CUSTOMER_ADMIN_PASSWORD', value: "${CUSTOMER_ADMIN_PASSWORD}"),
                         booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("${CLEAN_RESOURCES}")),

--- a/jobs/integr8ly/poc-testing-nightly-trigger.yaml
+++ b/jobs/integr8ly/poc-testing-nightly-trigger.yaml
@@ -27,7 +27,6 @@
             OC_USER=integreatly
             OC_PASSWORD=Password1
             EVALS_USERNAME=evals11@example.com
-            EVALS_PASSWORD=Password1
             CUSTOMER_ADMIN_PASSWORD=customer-admin@example.com
             CUSTOMER_ADMIN_PASSWORD=Password1
             CLEAN_RESOURCES=true
@@ -56,7 +55,6 @@
                         string(name: 'OC_USER', value: "${OC_USER}"),
                         string(name: 'OC_PASSWORD', value: "${OC_PASSWORD}"),
                         string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
-                        string(name: 'EVALS_PASSWORD', value: "${EVALS_PASSWORD}"),
                         string(name: 'CUSTOMER_ADMIN_USERNAME', value: "${CUSTOMER_ADMIN_USERNAME}"),
                         string(name: 'CUSTOMER_ADMIN_PASSWORD', value: "${CUSTOMER_ADMIN_PASSWORD}"),
                         booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("${CLEAN_RESOURCES}")),

--- a/jobs/integr8ly/three-scale-restoration.yaml
+++ b/jobs/integr8ly/three-scale-restoration.yaml
@@ -32,10 +32,6 @@
           default: 'evals11@example.com'
           description: 'Evals account email address for which 3scale data are generated.'
       - string:
-          name: EVALS_PASSWORD
-          default: 'Password1'
-          description: 'Evals user password'
-      - string:
           name: NAMESPACE_PREFIX
           description: "Value used to prefix the names of the namespaces created during Integr8ly installation"
       - string:
@@ -49,7 +45,6 @@
             string(name: 'CLUSTER_URL', value: "${CLUSTER_URL}"),
             string(name: 'WEBAPP_URL', value: "${WEBAPP_URL}"),
             string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
-            string(name: 'EVALS_PASSWORD', value: "${EVALS_PASSWORD}"),
             string(name: 'ADMIN_USERNAME', value: "${ADMIN_USERNAME}"),
             string(name: 'ADMIN_PASSWORD', value: "${ADMIN_PASSWORD}"),
             string(name: 'NAMESPACE_PREFIX', value: "${NAMESPACE_PREFIX}"),
@@ -115,7 +110,7 @@
 
                     stage('Publish test results') {
                         dir('test-suites/backend-testsuite/reports') {
-                            archiveArtifacts '**/*.xml'                  
+                            archiveArtifacts '**/*.xml'
                             junit allowEmptyResults:true, testResults: '**/*.xml'
                         }
                     }

--- a/jobs/integr8ly/w1-test-executor.yaml
+++ b/jobs/integr8ly/w1-test-executor.yaml
@@ -32,10 +32,6 @@
           default: 'evals11@example.com'
           description: 'Evals user name'
       - string:
-          name: EVALS_PASSWORD
-          default: 'Password1'
-          description: 'Evals user password'
-      - string:
           name: TIMEOUT_THRESHOLD
           default: '1'
           description: 'optionally increase timeout values. If you provide value 2 it means it will be sleeping/waiting two times longer'      
@@ -61,7 +57,6 @@
                                     string(name: 'ADMIN_USERNAME', value: "${ADMIN_USERNAME}"),
                                     string(name: 'ADMIN_PASSWORD', value: "${ADMIN_PASSWORD}"),
                                     string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
-                                    string(name: 'EVALS_PASSWORD', value: "${EVALS_PASSWORD}"),
                                     string(name: 'TIMEOUT_THRESHOLD', value: "${TIMEOUT_THRESHOLD}"),
                                     booleanParam(name: 'CLEAN_RESOURCES', value: false)
                                 ]).result;
@@ -81,7 +76,6 @@
                                     string(name: 'ADMIN_USERNAME', value: "${ADMIN_USERNAME}"),
                                     string(name: 'ADMIN_PASSWORD', value: "${ADMIN_PASSWORD}"),
                                     string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
-                                    string(name: 'EVALS_PASSWORD', value: "${EVALS_PASSWORD}"),
                                     string(name: 'TIMEOUT_THRESHOLD', value: "${TIMEOUT_THRESHOLD}"),
                                     booleanParam(name: 'CLEAN_RESOURCES', value: true),
                                     booleanParam(name: 'W1_FINAL_VERIFICATION', value: true)

--- a/jobs/integr8ly/w2-test-executor.yaml
+++ b/jobs/integr8ly/w2-test-executor.yaml
@@ -32,10 +32,6 @@
           default: 'evals11@example.com'
           description: 'Evals user name'
       - string:
-          name: EVALS_PASSWORD
-          default: 'Password1'
-          description: 'Evals user password'
-      - string:
           name: TIMEOUT_THRESHOLD
           default: '1'
           description: 'optionally increase timeout values. If you provide value 2 it means it will be sleeping/waiting two times longer'      
@@ -61,7 +57,6 @@
                                     string(name: 'ADMIN_USERNAME', value: "${ADMIN_USERNAME}"),
                                     string(name: 'ADMIN_PASSWORD', value: "${ADMIN_PASSWORD}"),
                                     string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
-                                    string(name: 'EVALS_PASSWORD', value: "${EVALS_PASSWORD}"),
                                     string(name: 'TIMEOUT_THRESHOLD', value: "${TIMEOUT_THRESHOLD}"),
                                     booleanParam(name: 'CLEAN_RESOURCES', value: true)
                                 ]).result;

--- a/jobs/openshift/cluster/integreatly/test/Jenkinsfile
+++ b/jobs/openshift/cluster/integreatly/test/Jenkinsfile
@@ -109,7 +109,6 @@ pipeline {
             [$class: 'StringParameterValue', name: 'BRANCH', value: 'master'],
             [$class: 'StringParameterValue', name: 'CLUSTER_URL', value: testOptions.openshiftMasterUrl],
             [$class: 'StringParameterValue', name: 'EVALS_USERNAME', value: 'evals05@example.com'],
-            [$class: 'StringParameterValue', name: 'EVALS_PASSWORD', value: 'Password1'],
             [$class: 'StringParameterValue', name: 'ADMIN_USERNAME', value: clusterAdminCredentials.clusterAdminUsername],
             [$class: 'StringParameterValue', name: 'ADMIN_PASSWORD', value: clusterAdminCredentials.clusterAdminPassword],
             [$class: 'StringParameterValue', name: 'CUSTOMER_ADMIN_USERNAME', value: 'customer-admin@example.com'],


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->
https://issues.jboss.org/browse/INTLY-2708

Removal of EVALS_PASSWORD parameter. Instead, I added ADMIN_USERNAME, ADMIN_PASSWORD, and NAMESPACE_PREFIX were needed since these three parameters are required for the test to retrieve the evals password itself.

I also removed a few trailing spaces on a few places.