### PR TITLE
added install backup ns feature to pds install related jobs and triggers

### DIFF
--- a/jobs/integr8ly/pds-install.yaml
+++ b/jobs/integr8ly/pds-install.yaml
@@ -38,6 +38,7 @@
             description: "User capable of SSH-ing to bastion server"
         - string:
             name: BASTION_PRIVATE_KEY_ID
+            default: pds-bastion-pem
             description: "ID of SSH Credentials (private key) used for SSH-ing to bastion"
         - string:
             name: ADDITIONAL_ANSIBLE_PARAMS
@@ -46,6 +47,10 @@
             name: PATCH_TO_MASTER
             default: false
             description: "Indicates whether the components should be patched to master during installation"
+        - bool:
+            name: INSTALL_BACKUPS
+            default: false
+            description: "Indicates whether backups namespace should be installed during Integr8ly installation"
         - string:
             name: NAMESPACE_PREFIX
             description: "This value will be prefixed to the names of the namespaces created during Integr8ly installation. Defaulting to empty string for RHPDS"
@@ -66,10 +71,11 @@
                                   "backup_version"]
         String MASTER_URL = "master1.${YOURCITY}.internal"
         String BASTION_URL = "bastion.${YOURCITY}.openshiftworkshop.com"    
-        String bastionLabel = "${BASTION_URL}-slave"                      
-        
+        String bastionLabel = "${BASTION_URL}-slave"   
+        String secretFileName = "QE-AWS-SECRET.yml"                   
+        def secretContent
         try {
-            timeout(60) { ansiColor('gnome-terminal') { timestamps {
+            timeout(75) { ansiColor('gnome-terminal') { timestamps {
                 node('cirhos_rhel7') {       
                     stage('Verify input') {
                         if (!YOURCITY) {
@@ -115,6 +121,12 @@
                             println "Slave ${bastionLabel} has been created successfully."
                         } // end if
                     } // stage
+
+                    stage('Obtain s3-credentials secret for backups namespace') {
+                        if (INSTALL_BACKUPS.toString() == 'true') {
+                            secretContent = sh (returnStdout: true, script: 'curl -k https://gitlab.cee.redhat.com/integreatly-qe/integreatly-qe/raw/development/resources/QE-AWS-SECRET.yml')
+                        }
+                    } // stage
                 } // node
 
                 node(bastionLabel) {
@@ -139,6 +151,7 @@
                     stage('Prepare environment') {
                         dir('installation') {
                             sh """
+                                sudo oc login -u system:admin
                                 cp ./evals/inventories/hosts.template ./evals/inventories/hosts
                                 sed -i 's/ansible_user=ec2-user/ansible_user=${ANSIBLE_USER}/g' ./evals/inventories/hosts
                             """
@@ -162,6 +175,27 @@
                                     """
                                 }
                             }
+                            if (INSTALL_BACKUPS.toString() == 'true') {
+                                String backupsNamespace = 'openshift-integreatly-backups';
+                                String secretName = 's3-credentials';
+                                String obtainSecretsCommand = 'sudo oc get secrets -n ' + backupsNamespace
+
+                                def projects = sh(script: 'sudo oc projects', returnStdout: true)
+                                if (!projects.contains(backupsNamespace)) {
+                                    sh """
+                                        sudo oc create ns ${backupsNamespace}
+                                    """
+                                }
+                                
+                                def secrets = sh(script: obtainSecretsCommand, returnStdout: true)
+                                if (!secrets.contains(secretName)) {
+                                    writeYaml file: secretFileName, data: secretContent
+                                    sh """
+                                        sudo oc create -f ${secretFileName}
+                                        rm ${secretFileName}
+                                    """
+                                }
+                            }
                         } // dir
                     } // stage
                     
@@ -175,16 +209,18 @@
                             if (ADDITIONAL_ANSIBLE_PARAMS.indexOf('eval_seed_users_count') == -1) {
                                 ansibleParams = ansibleParams + " -e eval_seed_users_count=15"
                             }
+                            if (INSTALL_BACKUPS.toString() == 'true') {
+                                ansibleParams = ansibleParams + " -e backup_restore_install=true"
+                            }
                             ansibleParams = ansibleParams + " ${ADDITIONAL_ANSIBLE_PARAMS}"
                             
                             sh """
-                                sudo oc login -u system:admin
                                 sudo ansible-playbook -i ./inventories/hosts ./playbooks/install.yml ${ansibleParams} -e eval_self_signed_certs=${SELF_SIGNED_CERTS} -e ns_prefix=${NAMESPACE_PREFIX}
                             """
                         } // dir
                     } // stage
 
-                     stage('Execute "After Installation" Workarounds') {
+                    stage('Execute "After Installation" Workarounds') {
                         if (BRANCH == 'master' && PATCH_TO_MASTER.toString() == 'true') {  
                             sleep time: 2, unit: 'MINUTES' // to make sure that everything is ready to be patched
                             sh """

--- a/jobs/integr8ly/pds-testing-executor.yaml
+++ b/jobs/integr8ly/pds-testing-executor.yaml
@@ -84,6 +84,10 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             name: PATCH_TO_MASTER
             default: false
             description: "Indicates whether the components should be patched to master during installation"
+        - bool:
+            name: INSTALL_BACKUPS
+            default: false
+            description: "Indicates whether backups namespace should be installed during Integr8ly installation"
         - string:
             name: NAMESPACE_PREFIX
             description: "This value will be prefixed to the names of the namespaces created during Integr8ly installation. Defaulting to empty string for RHPDS"
@@ -170,7 +174,8 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                 string(name: 'YOURCITY', value: "${YOURCITY}"),
                 string(name: 'BASTION_USER', value: 'ec2-user'),
                 string(name: 'NAMESPACE_PREFIX', value: "${NAMESPACE_PREFIX}"),
-                string(name: 'BASTION_PRIVATE_KEY_ID', value: 'pds-bastion-pem')]
+                string(name: 'BASTION_PRIVATE_KEY_ID', value: 'pds-bastion-pem')
+            ]
 
             sleep time: sleepTime, unit: 'MINUTES'
         }
@@ -181,13 +186,15 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
                 string(name: 'BRANCH', value: "${INSTALLATION_BRANCH}"),
                 string(name: 'GH_CLIENT_ID', value: "${GH_CLIENT_ID}"),
                 string(name: 'GH_CLIENT_SECRET', value: "${GH_CLIENT_SECRET}"),
+                booleanParam(name: 'INSTALL_BACKUPS', value: Boolean.valueOf("${INSTALL_BACKUPS}")),
                 booleanParam(name: 'PATCH_TO_MASTER', value: Boolean.valueOf("${PATCH_TO_MASTER}")),
                 booleanParam(name: 'SELF_SIGNED_CERTS', value: Boolean.valueOf("${SELF_SIGNED_CERTS}")),
                 string(name: 'ANSIBLE_USER', value: 'ec2-user'),
                 string(name: 'YOURCITY', value: "${YOURCITY}"),
                 string(name: 'BASTION_USER', value: 'ec2-user'),
                 string(name: 'NAMESPACE_PREFIX', value: "${NAMESPACE_PREFIX}"),
-                string(name: 'BASTION_PRIVATE_KEY_ID', value: 'pds-bastion-pem')]
+                string(name: 'BASTION_PRIVATE_KEY_ID', value: 'pds-bastion-pem')
+            ]
             
             if (sleepAfterInstall) {
                 sleep time: 3, unit: 'MINUTES'
@@ -195,7 +202,6 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
         }
 
         def runTests() {
-
             parameters = [
                 string(name: 'REPOSITORY', value: "${TEST_SUITES_REPOSITORY}"),
                 string(name: 'BRANCH', value: "${TEST_SUITES_BRANCH}"),

--- a/jobs/integr8ly/pds-testing-nightly-no-patch-trigger.yaml
+++ b/jobs/integr8ly/pds-testing-nightly-no-patch-trigger.yaml
@@ -29,6 +29,7 @@
             CUSTOMER_ADMIN_PASSWORD=Password1
             CLEAN_RESOURCES=true
             MANIFEST_VERSION=master
+            INSTALL_BACKUPS=false
             TESTING_MASTER=false
             NUMBER_OF_USERS=5
             PATCH_TO_MASTER=false
@@ -57,6 +58,7 @@
                         booleanParam(name: 'TESTING_MASTER', value: Boolean.valueOf("${TESTING_MASTER}")),
                         string(name: 'NUMBER_OF_USERS', value: "${NUMBER_OF_USERS}"),
                         booleanParam(name: 'PATCH_TO_MASTER', value: Boolean.valueOf("${PATCH_TO_MASTER}")),
+                        booleanParam(name: 'INSTALL_BACKUPS', value: Boolean.valueOf("${INSTALL_BACKUPS}")),
                         string(name: 'TO_DO', value: "${TO_DO}")
                     ]).result
 

--- a/jobs/integr8ly/pds-testing-nightly-trigger.yaml
+++ b/jobs/integr8ly/pds-testing-nightly-trigger.yaml
@@ -29,6 +29,7 @@
             CUSTOMER_ADMIN_PASSWORD=Password1
             CLEAN_RESOURCES=true
             MANIFEST_VERSION=master
+            INSTALL_BACKUPS=false
             TESTING_MASTER=true
             NUMBER_OF_USERS=5
             PATCH_TO_MASTER=true
@@ -57,6 +58,7 @@
                         booleanParam(name: 'TESTING_MASTER', value: Boolean.valueOf("${TESTING_MASTER}")),
                         string(name: 'NUMBER_OF_USERS', value: "${NUMBER_OF_USERS}"),
                         booleanParam(name: 'PATCH_TO_MASTER', value: Boolean.valueOf("${PATCH_TO_MASTER}")),
+                        booleanParam(name: 'INSTALL_BACKUPS', value: Boolean.valueOf("${INSTALL_BACKUPS}")),
                         string(name: 'TO_DO', value: "${TO_DO}")
                     ]).result
 


### PR DESCRIPTION
## What
added install backup ns feature to pds install related jobs and triggers

## Verification
1. Go to this pipeline: https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/all/job/backups-pds-install/25/console and confirm that at the beginning of the build the backups namespace and secret get created (search for: **namespace/openshift-integreatly-backups created** and **secret/s3-credentials created**
2. After the pipeline completes, login to the cluster, on which integreatly was installed and confirm that the backups namespace is present.
3. Run any of one time jobs and make sure that the job completes, e.g. s3 url for the backed up files is available

Alternatively run the job yourself and go through verification step 2 and 3
