### PR TITLE
Job updated to dynamically retrieve docker-registry route

### DIFF
--- a/jobs/openshift/cluster/brew/Jenkinsfile
+++ b/jobs/openshift/cluster/brew/Jenkinsfile
@@ -112,7 +112,7 @@ node('cirhos_rhel7') {
 
     stage('Sync Images') {
         when(syncImages) {
-            String clusterContainerRegistryPublic = "docker-registry-default.apps.${getHost(imageSyncOptions.openshiftMasterUrl)}"
+            imageSyncOptions.dockerRegistryRoute = sh(returnStdout: true, script: "oc get route/docker-registry -o jsonpath='{.spec.host}' -n default").trim()
             projectsToSync.each { project, projectConfig ->
                 println "Syncing images for ${project}"
                 brewContainerRegistry = projectConfig.sourceRepo ?: brewContainerRegistry
@@ -123,7 +123,7 @@ node('cirhos_rhel7') {
                     projectConfig.images.each {
                         try {
                             def brewImageUrl = "${brewContainerRegistry}/${project}/${it}"
-                            def clusterImageUrlPub = "${clusterContainerRegistryPublic}/${project}/${it}"
+                            def clusterImageUrlPub = "${imageSyncOptions.dockerRegistryRoute}/${project}/${it}"
 
                             if (params.dryRun) {
                                 println "Would copy the image '${it}' from ${brewImageUrl} to ${clusterImageUrlPub}"
@@ -144,7 +144,7 @@ node('cirhos_rhel7') {
                         } catch (Exception e) {
                             //If the above fails, this will just check if the image is actually in a tech-preview repo instead, as was the case for fuse7-tech-preview/fuse-postgres-exporter:1.4-1
                             def brewImageUrl = "${brewContainerRegistry}/${project}-tech-preview/${it}"
-                            def clusterImageUrlPub = "${clusterContainerRegistryPublic}/${project}/${it}"
+                            def clusterImageUrlPub = "${imageSyncOptions.dockerRegistryRoute}/${project}/${it}"
 
                             retry(3) {
                                 sh """


### PR DESCRIPTION
## Additional Information

The current Brew sync image job has a hard-coded values for the docker-registry (line 115): `docker-registry-default.apps`. This will not work if the route to the docker-registry is named differently, thus the script was updated to dynamically pull retrieve the route using an `oc` command.

https://issues.jboss.org/browse/INTLY-2766

## Prerequisites

- Access to the `integreatly-qe` Jenkins server

## Verification Steps

- Replace the current brew image sync script with one in this PR

- Run the brew image sync job should be run against clusters in the following environments, ensuring successful completion in each:

  - [x] OSD
  - [x] POC
  - [x] RHPDS

## Note

In the event of a failure, please remember to replace the script with the original version.