### PR TITLE
Adjusted to new PDS domain

### DIFF
--- a/jobs/integr8ly/pds-install.yaml
+++ b/jobs/integr8ly/pds-install.yaml
@@ -70,7 +70,7 @@
                                   "middleware_monitoring_operator_release_tag",
                                   "backup_version"]
         String MASTER_URL = "master1.${YOURCITY}.internal"
-        String BASTION_URL = "bastion.${YOURCITY}.openshiftworkshop.com"    
+        String BASTION_URL = "bastion.${YOURCITY}.open.redhat.com"    
         String bastionLabel = "${BASTION_URL}-slave"   
         String secretFileName = "QE-AWS-SECRET.yml"                   
         def secretContent

--- a/jobs/integr8ly/pds-testing-executor.yaml
+++ b/jobs/integr8ly/pds-testing-executor.yaml
@@ -205,18 +205,18 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             parameters = [
                 string(name: 'REPOSITORY', value: "${TEST_SUITES_REPOSITORY}"),
                 string(name: 'BRANCH', value: "${TEST_SUITES_BRANCH}"),
-                string(name: 'CLUSTER_URL', value: "https://master.${YOURCITY}.openshiftworkshop.com"),
+                string(name: 'CLUSTER_URL', value: "https://master.${YOURCITY}.open.redhat.com"),
                 string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
                 string(name: 'ADMIN_USERNAME', value: "${ADMIN_USERNAME}"),
                 string(name: 'ADMIN_PASSWORD', value: "${ADMIN_PASSWORD}"),
                 string(name: 'CUSTOMER_ADMIN_USERNAME', value: "${CUSTOMER_ADMIN_USERNAME}"),
                 string(name: 'CUSTOMER_ADMIN_PASSWORD', value: "${CUSTOMER_ADMIN_PASSWORD}"),
                 string(name: 'NAMESPACE_PREFIX', value: "${NAMESPACE_PREFIX}"),
-                string(name: 'WEBAPP_URL', value: "https://tutorial-web-app-${NAMESPACE_PREFIX}webapp.apps.${YOURCITY}.openshiftworkshop.com"),
+                string(name: 'WEBAPP_URL', value: "https://tutorial-web-app-${NAMESPACE_PREFIX}webapp.apps.${YOURCITY}.open.redhat.com"),
                 booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("${CLEAN_RESOURCES}")),
                 string(name: 'MANIFEST_VERSION', value: "${MANIFEST_VERSION}"),
                 booleanParam(name: 'TESTING_MASTER', value: Boolean.valueOf("${TESTING_MASTER}")),
-                string(name: 'SSO_URL', value: "https://sso-${NAMESPACE_PREFIX}sso.apps.${YOURCITY}.openshiftworkshop.com"),
+                string(name: 'SSO_URL', value: "https://sso-${NAMESPACE_PREFIX}sso.apps.${YOURCITY}.open.redhat.com"),
                 string(name: 'NUMBER_OF_USERS', value: "${NUMBER_OF_USERS}")
             ]
 

--- a/jobs/integr8ly/pds-uninstall.yaml
+++ b/jobs/integr8ly/pds-uninstall.yaml
@@ -41,7 +41,7 @@
         import hudson.plugins.sshslaves.verifiers.*
 
         String MASTER_URL = "master1.${YOURCITY}.internal"
-        String BASTION_URL = "bastion.${YOURCITY}.openshiftworkshop.com"    
+        String BASTION_URL = "bastion.${YOURCITY}.open.redhat.com"    
         String bastionLabel = "${BASTION_URL}-slave"
 
         try {

--- a/jobs/ocp4/pds-ocp4-install.yaml
+++ b/jobs/ocp4/pds-ocp4-install.yaml
@@ -76,7 +76,7 @@
             registryNamespace = params.REGISTRY_NAMESPACE
         }
 
-        String clusterAPI = "https://api.cluster-${RHPDS_CITY}.${RHPDS_CITY}.openshiftworkshop.com:6443"
+        String clusterAPI = "https://api.cluster-${RHPDS_CITY}.${RHPDS_CITY}.open.redhat.com:6443"
 
         // by default build number is used as namespacePrefix to prevent clashes with previous Integreatly Operator deployments
         String namespacePrefix = BUILD_NUMBER
@@ -189,8 +189,8 @@
                         sh(
                             returnStdout: false,
                             script: """
-                                sed -i "s@http://master.example.com@https://console-openshift-console.apps.cluster-${RHPDS_CITY}.${RHPDS_CITY}.openshiftworkshop.com@" ./integreatly-operator/deploy/crds/examples/installation.cr.yaml
-                                sed -i "s@example.com@apps.cluster-${RHPDS_CITY}.${RHPDS_CITY}.openshiftworkshop.com@" ./integreatly-operator/deploy/crds/examples/installation.cr.yaml
+                                sed -i "s@http://master.example.com@https://console-openshift-console.apps.cluster-${RHPDS_CITY}.${RHPDS_CITY}.open.redhat.com@" ./integreatly-operator/deploy/crds/examples/installation.cr.yaml
+                                sed -i "s@example.com@apps.cluster-${RHPDS_CITY}.${RHPDS_CITY}.open.redhat.com@" ./integreatly-operator/deploy/crds/examples/installation.cr.yaml
                                 sed -i "s@integreatly-@${namespacePrefix}-integreatly-@" ./integreatly-operator/deploy/crds/examples/installation.cr.yaml
                                 sed -i "s@type: workshop@type: ${INSTALLATION_TYPE}@" ./integreatly-operator/deploy/crds/examples/installation.cr.yaml
 


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Adjusted to new RHPDS domain. This is what new domain looks like:
https://master.trepel-76cc.open.redhat.com:443

## Verification

Just eye review and maybe grep for 'openshiftworkshop' occurrences whether I did not miss any. I will verify after merge on the aforementioned RHPDS cluster
