### PR TITLE
moved dedicated-admin install to ocp4-install and allowed using custom password

### DIFF
--- a/jobs/integr8ly/ocp4/ocp4-install.yaml
+++ b/jobs/integr8ly/ocp4/ocp4-install.yaml
@@ -31,6 +31,10 @@
             default: ''
             description: "Admin password for OS4 cluster"
         - string:
+            name: CUSTOMER_ADMIN_PASSWORD
+            default: 'Password1'
+            description: "Password used when adding dedicated-admin. If empty - random password will be generated"
+        - string:
             name: INTEGREATLY_OPERATOR_REPOSITORY
             default: 'https://github.com/integr8ly/integreatly-operator.git'
             description: "Repository of the Integreatly Operator"
@@ -255,14 +259,12 @@
                     } // stage
 
                     stage ('Install dedicated-admin') {
-                        if (isPds) {
-                            dir("integreatly-operator") {
-                                git branch: "${INTEGREATLY_OPERATOR_BRANCH}", url: "${INTEGREATLY_OPERATOR_REPOSITORY}"
-                            }
-                            dir("integreatly-operator/scripts") {
-                                sh "oc login ${clusterAPI} --insecure-skip-tls-verify=true -u ${ADMIN_USERNAME} -p ${adminPassword}"
-                                sh "./dedicated-setup.sh"
-                            }
+                        dir("integreatly-operator") {
+                            git branch: "${INTEGREATLY_OPERATOR_BRANCH}", url: "${INTEGREATLY_OPERATOR_REPOSITORY}"
+                        }
+                        dir("integreatly-operator/scripts") {
+                            sh "oc login ${clusterAPI} --insecure-skip-tls-verify=true -u ${ADMIN_USERNAME} -p ${adminPassword}"
+                            sh "export CUSTOM_PWD=${CUSTOMER_ADMIN_PASSWORD} && ./dedicated-setup.sh"
                         }
                     } // stage                    
                 } catch (caughtError){

--- a/jobs/openshift4/cluster/create/Jenkinsfile
+++ b/jobs/openshift4/cluster/create/Jenkinsfile
@@ -97,19 +97,7 @@ node("cirhos_rhel7") {
                     script: "cat ${installConfigDirectory}log.file",
                     returnStdout: true
                 ).trim()
-                if (installationLog.contains("Install complete")) {
-                    adminPassword = sh (
-                        script: "cat ${installConfigDirectory}auth/kubeadmin-password",
-                        returnStdout: true
-                    ).trim()
-                    dir("integreatly-operator") {
-                        git branch: "master", url: "https://github.com/integr8ly/integreatly-operator.git"
-                    }
-                    dir("integreatly-operator/scripts") {
-                        sh "oc login https://api.${clusterName}.${baseDomain}:6443 --insecure-skip-tls-verify=true -u kubeadmin -p ${adminPassword}"
-                        sh "./dedicated-setup.sh"
-                    }
-                } else {
+                if (!installationLog.contains("Install complete")) {
                     build (job: 'openshift4-cluster-deprovision', parameters:[
                         [$class: 'StringParameterValue', name: 'CLUSTER_NAME', value: CLUSTER_NAME],
                         [$class: 'StringParameterValue', name: 'RECIPIENTS', value: RECIPIENTS],


### PR DESCRIPTION
## What
moved dedicated-admin install to ocp4-install and allowed using custom password

## Verification
The pipeline with changed definition was executed here: https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/all/job/ppaszki-ocp4-install/45/console 
