### PR TITLE
Added CLEAN_RESOURES to wt1 executor

### DIFF
--- a/jobs/integr8ly/ocp3/test-suites/w1-test-executor.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/w1-test-executor.yaml
@@ -31,6 +31,10 @@
           name: EVALS_USERNAME
           default: 'evals11@example.com'
           description: 'Evals user name'
+      - bool:
+          name: CLEAN_RESOURCES
+          default: true
+          description: 'depending on whether the resources should be cleaned after the successful execution'
       - string:
           name: TIMEOUT_THRESHOLD
           default: '1'
@@ -77,7 +81,7 @@
                                     string(name: 'ADMIN_PASSWORD', value: "${ADMIN_PASSWORD}"),
                                     string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
                                     string(name: 'TIMEOUT_THRESHOLD', value: "${TIMEOUT_THRESHOLD}"),
-                                    booleanParam(name: 'CLEAN_RESOURCES', value: true),
+                                    booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("${CLEAN_RESOURCES}")),
                                     booleanParam(name: 'W1_FINAL_VERIFICATION', value: true)
                                 ]).result;
 


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Added CLEAN_RESOURCES param to wt1 executor (similarly to other tests). Useful if you want to keep the resources for subsequent manual work or (for instance) upgrade.

This should also make sure that if you set CLEAN_RESOURCES to 'false' in all-test-executor, it is properly propagated to wt1 executor.

Successful Jenkins run:
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Test%20Suites/job/w1-test-executor/532/ (config from this PR has been used).

Verification Steps:
probably just eye review, we have these pieces all over the place.
