### PR TITLE
added test stage to testing executor with running cust-adm perm tests

### DIFF
--- a/jobs/integr8ly/ocp4/nightly/osd-ocp4-testing-nightly-trigger.yaml
+++ b/jobs/integr8ly/ocp4/nightly/osd-ocp4-testing-nightly-trigger.yaml
@@ -22,16 +22,19 @@
             REGISTRY_NAMESPACE=integreatly
             INSTALLATION_TYPE=managed
             ADMIN_USERNAME=kubeadmin
+            CUSTOMER_ADMIN_USERNAME=customer-admin
+            CUSTOMER_ADMIN_PASSWORD=Password1
             GH_CLIENT_ID=yourclientsecret
             GH_CLIENT_SECRET=yourclientsecret
             TEST_SUITES_REPOSITORY=https://gitlab.cee.redhat.com/integreatly-qe/integreatly-qe.git
-            TEST_SUITES_BRANCH=master
+            TEST_SUITES_BRANCH=v2-master
             RECIPIENTS=integreatly-qe@redhat.com
             COMPUTE_REPLICAS=3
             CONTROL_PLANE_REPLICAS=3
             AWS_REGION=eu-west-1
             CREDENTIALS_ID=iam-openshift4-credentials
-            TO_DO=provision + install + deprovision
+            NAMESPACE_PREFIX=openshift-
+            TO_DO=provision + install + tests + deprovision
     dsl: |
         timeout(240) { ansiColor('gnome-terminal') { timestamps {
             node('cirhos_rhel7') {
@@ -46,6 +49,8 @@
                         string(name: 'REGISTRY_NAMESPACE', value: "${REGISTRY_NAMESPACE}"),
                         string(name: 'INSTALLATION_TYPE', value: "${INSTALLATION_TYPE}"),
                         string(name: 'ADMIN_USERNAME', value: "${ADMIN_USERNAME}"),
+                        string(name: 'CUSTOMER_ADMIN_USERNAME', value: "${CUSTOMER_ADMIN_USERNAME}"),
+                        string(name: 'CUSTOMER_ADMIN_PASSWORD', value: "${CUSTOMER_ADMIN_PASSWORD}"),
                         string(name: 'GH_CLIENT_ID', value: "${GH_CLIENT_ID}"),
                         string(name: 'GH_CLIENT_SECRET', value: "${GH_CLIENT_SECRET}"),
                         string(name: 'TEST_SUITES_REPOSITORY', value: "${TEST_SUITES_REPOSITORY}"),
@@ -55,6 +60,7 @@
                         string(name: 'CONTROL_PLANE_REPLICAS', value: "${CONTROL_PLANE_REPLICAS}"),
                         string(name: 'AWS_REGION', value: "${AWS_REGION}"),
                         string(name: 'CREDENTIALS_ID', value: "${CREDENTIALS_ID}"),
+                        string(name: 'NAMESPACE_PREFIX', value: "${NAMESPACE_PREFIX}"),
                         string(name: 'TO_DO', value: "${TO_DO}")
                     ]).result
 

--- a/jobs/integr8ly/ocp4/ocp4-install.yaml
+++ b/jobs/integr8ly/ocp4/ocp4-install.yaml
@@ -54,6 +54,7 @@
               - managed
         - string:
             name: NAMESPACE_PREFIX
+            default: 'openshift-'
             description: "Prefix of Integreatly Operator namespace, defauls to `BUILD_NUMBER`"
         - bool:
             name: CLEANUP_BEFOREHAND
@@ -78,14 +79,13 @@
             description: "Repository of Integreatly test suites, YAML templates are stored there"
         - string:
             name: TEST_SUITES_BRANCH
-            default: 'development'
+            default: 'v2-master'
             description: "Branch of Integreatly test suites repository"
         - string:
             name: RECIPIENTS
             default: 'integreatly-qe@redhat.com'
             description: "Whitespace- or comma-separated list of recipient addresses"
     dsl: |
-        #!groovy
         Boolean cleanupBeforehand = params.CLEANUP_BEFOREHAND
         Boolean cleanupAfterward = params.CLEANUP_AFTERWARD
         Boolean selfSignedCerts = params.SELF_SIGNED_CERTS

--- a/jobs/integr8ly/ocp4/ocp4-testing-executor.yaml
+++ b/jobs/integr8ly/ocp4/ocp4-testing-executor.yaml
@@ -34,8 +34,20 @@
           default: ''
           description: "Jenkins Credentials for RHPDS admin user"
       - string:
+          name: CUSTOMER_ADMIN_USERNAME
+          default: 'customer-admin'
+          description: "customer-admin username to login to Integreatly cluster"
+      - string:
+          name: CUSTOMER_ADMIN_PASSWORD
+          default: 'Password1'
+          description: "customer-adnim password to login to Integreatly cluster"
+      - string:
+          name: EVALS_USERNAME
+          default: 'evals11@example.com'
+          description: "evals account email address used in test suites"
+      - string:
           name: INTEGREATLY_OPERATOR_REPOSITORY
-          default: 'https://github.com/integr8ly/integreatly-operator.git'
+          default: "https://github.com/integr8ly/integreatly-operator.git"
           description: "Repository of the Integreatly Operator"
       - string:
           name: INTEGREATLY_OPERATOR_BRANCH
@@ -53,6 +65,7 @@
             - managed
       - string:
           name: NAMESPACE_PREFIX
+          default: 'openshift-'
           description: "Prefix of Integreatly Operator namespace, defauls to `BUILD_NUMBER`"
       - bool:
           name: CLEANUP_BEFOREHAND
@@ -77,12 +90,16 @@
           description: "Repository of Integreatly test suites, YAML templates are stored there"
       - string:
           name: TEST_SUITES_BRANCH
-          default: 'master'
+          default: 'v2-master'
           description: "Branch of Integreatly test suites repository"
       - string:
           name: RECIPIENTS
           default: 'integreatly-qe@redhat.com'
           description: "Whitespace- or comma-separated list of recipient addresses"
+      - string:
+          name: TIMEOUT_THRESHOLD
+          default: '1'
+          description: 'optionally increase timeout values. If you provide value 2 it means it will be sleeping/waiting two times longer'      
       - choice:
           name: 'AWS_REGION'
           choices:
@@ -114,12 +131,14 @@
           name: TO_DO
           description: "It specifies what stages of the pipeline will be executed. Provision and deprovision are for non-pds clusters only"
           choices:
-            - provision + install + deprovision
+            - provision + install + tests + deprovision
+            - provision + install + tests
             - provision + install
+            - install + tests
             - install
     dsl: |
         def err = null
-        
+
         try {
             timeout(240) { ansiColor('gnome-terminal') { timestamps {
                 node('cirhos_rhel7') {
@@ -135,10 +154,20 @@
                     stage ('Install') {
                         install()
                     } // stage
+
+                    stage ('Test') {
+                        if (TO_DO.contains('tests')) {
+                            test()
+                        } else {
+                            println 'Tests skipped'
+                        }
+                    } // stage
                     
                     stage ('Deprovision') {
                         if (TO_DO.contains('deprovision')) {
                             deprovisionCluster()
+                        } else {
+                            println 'Deprovision skipped'
                         }
                     } // stage
 
@@ -172,6 +201,7 @@
                 booleanParam(name: 'SELF_SIGNED_CERTS', value: Boolean.valueOf("${SELF_SIGNED_CERTS}")),
                 string(name: 'ADMIN_USERNAME', value: "${ADMIN_USERNAME}"),
                 string(name: 'ADMIN_PASSWORD', value: "${ADMIN_PASSWORD}"),
+                string(name: 'CUSTOMER_ADMIN_PASSWORD', value: "${CUSTOMER_ADMIN_PASSWORD}"),
                 string(name: 'INTEGREATLY_OPERATOR_REPOSITORY', value: "${INTEGREATLY_OPERATOR_REPOSITORY}"),
                 string(name: 'INTEGREATLY_OPERATOR_BRANCH', value: "${INTEGREATLY_OPERATOR_BRANCH}"),
                 string(name: 'REGISTRY_NAMESPACE', value: "${REGISTRY_NAMESPACE}"),
@@ -190,6 +220,25 @@
                 string(name: 'AWS_REGION', value: "${AWS_REGION}"),
                 string(name: 'CREDENTIALS_ID', value: "${CREDENTIALS_ID}"),
                 string(name: 'TO_DO', value: "${TO_DO}")
+            ]
+        }
+
+        def test() {
+            Boolean isPds = params.PDS_CLUSTER
+            String clusterSuffix = isPds ? "cluster-${CLUSTER_NAME}.${CLUSTER_NAME}.${CLUSTER_DOMAIN}" : "${CLUSTER_NAME}.${CLUSTER_DOMAIN}"
+            String clusterURL = "https://api.${clusterSuffix}:6443"
+            build job: 'ocp4-all-tests-executor', parameters: [
+                string(name: 'REPOSITORY', value: "${TEST_SUITES_REPOSITORY}"),
+                string(name: 'BRANCH', value: "${TEST_SUITES_BRANCH}"),
+                string(name: 'CLUSTER_URL', value: "${clusterURL}"),
+                string(name: 'CLUSTER_NAME', value: "${CLUSTER_NAME}"),
+                string(name: 'ADMIN_USERNAME', value: "${ADMIN_USERNAME}"),
+                string(name: 'ADMIN_PASSWORD', value: "${ADMIN_PASSWORD}"),
+                string(name: 'CUSTOMER_ADMIN_USERNAME', value: "${CUSTOMER_ADMIN_USERNAME}"),
+                string(name: 'CUSTOMER_ADMIN_PASSWORD', value: "${CUSTOMER_ADMIN_PASSWORD}"),
+                string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
+                string(name: 'NAMESPACE_PREFIX', value: "${NAMESPACE_PREFIX}"),
+                string(name: 'TIMEOUT_THRESHOLD', value: "${TIMEOUT_THRESHOLD}")
             ]
         }
 

--- a/jobs/integr8ly/ocp4/tests/ocp4-all-tests-executor.yaml
+++ b/jobs/integr8ly/ocp4/tests/ocp4-all-tests-executor.yaml
@@ -1,0 +1,164 @@
+---
+
+- job:
+    name: ocp4-all-tests-executor
+    project-type: pipeline
+    description: "Pipeline to run all of the available OS4 RHMI tests"
+    sandbox: true
+    properties:
+      - build-discarder:
+          num-to-keep: 56
+    parameters:
+      - string:
+          name: REPOSITORY
+          default: 'https://gitlab.cee.redhat.com/integreatly-qe/integreatly-qe.git'
+          description: 'QE repository containing the smoke tests source code.'
+      - string:
+          name: BRANCH
+          default: 'v2-master'
+          description: 'Branch of the repository'
+      - string:
+          name: CLUSTER_URL
+          description: 'URL of cluster on which the smoke tests will be executed.'
+      - string:
+          name: CLUSTER_NAME
+          description: "City or customer for RHPDS cluster, for example qe-ocp4-[hash] or cluster name specified when creating it using openshift-install"
+      - string:
+          name: ADMIN_USERNAME
+          default: 'kubeadmin'
+          description: 'Admin sername to login to Integreatly cluster.'
+      - string:
+          name: ADMIN_PASSWORD
+          default: ''
+          description: 'Admin password to login to Integreatly cluster.'
+      - string:
+          name: CUSTOMER_ADMIN_USERNAME
+          default: 'customer-admin'
+          description: 'customer-admin username to login to Integreatly cluster.'
+      - string:
+          name: CUSTOMER_ADMIN_PASSWORD
+          default: 'Password1'
+          description: 'Password to login to Integreatly cluster.'
+      - string:
+          name: EVALS_USERNAME
+          default: 'evals11@example.com'
+          description: 'Evals account email address for checking created namespaces.'    
+      - string:
+          name: NAMESPACE_PREFIX
+          default: 'openshift-'
+          description: 'Value used to prefix the names of the namespaces created during Integr8ly installation'
+      - string:
+          name: TIMEOUT_THRESHOLD
+          default: '1'
+          description: 'optionally increase timeout values. If you provide value 2 it means it will be sleeping/waiting two times longer'
+    dsl: |
+        jobParams = [
+            string(name: 'REPOSITORY', value: "${REPOSITORY}"),
+            string(name: 'BRANCH', value: "${BRANCH}"),
+            string(name: 'CLUSTER_URL', value: "${CLUSTER_URL}"),
+            string(name: 'ADMIN_USERNAME', value: "${ADMIN_USERNAME}"),
+            string(name: 'CUSTOMER_ADMIN_PASSWORD', value: "${CUSTOMER_ADMIN_PASSWORD}"),
+            string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
+            string(name: 'NAMESPACE_PREFIX', value: "${NAMESPACE_PREFIX}"),
+            string(name: 'TIMEOUT_THRESHOLD', value: "${TIMEOUT_THRESHOLD}")
+        ]
+        def err = null
+        def wtTestStatus;
+        String adminPassword = params.ADMIN_PASSWORD
+        try {
+            timeout(180) { ansiColor('gnome-terminal') { timestamps {
+                node('cirhos_rhel7') {
+                    stage ("Obtain admin password") {
+                        if (ADMIN_USERNAME == 'kubeadmin' && adminPassword.toString().length() == 0) {
+                            String loginCredentialDirectory = "clusters/${CLUSTER_NAME}/auth/kubeadmin-password"
+                            dir("rhmi-jenkins") {
+                                git branch: "master", url: "https://gitlab.cee.redhat.com/integreatly-qe/rhmi-jenkins.git"
+                                def dirExists = fileExists(loginCredentialDirectory)
+                                if (!dirExists) {
+                                    error noConfigFilesError
+                                }
+                                adminPassword = sh (
+                                    script: "cat ${loginCredentialDirectory}",
+                                    returnStdout: true
+                                ).trim()
+                            }
+                        }
+                        jobParams.add(string(name: 'ADMIN_PASSWORD', value: "${adminPassword}"))
+                    }
+
+                    stage ("Dedicated admin permissions") {
+                        // this sleep time is required to finish up setting up oauth config after installation. In the future it can be replaced by a test(s)
+                        // that can be executed straight after the installation that don't require customer-admin interactions
+                        sleep time: 75, unit: 'SECONDS'
+                        sh "oc login ${CLUSTER_URL} -u ${CUSTOMER_ADMIN_USERNAME} -p ${CUSTOMER_ADMIN_PASSWORD} --insecure-skip-tls-verify # to 'enable' the user"
+                        // sleep is required to properly 'enable' customer-admin by the operator. In the future it can be replaced by a test(s)
+                        // that can be executed straight after the installation that don't require customer-admin interactions
+                        sleep time: 2, unit: 'MINUTES'
+                        parameters = jobParams
+                        parameters.add(string(name: 'CUSTOMER_ADMIN_USERNAME', value: "${CUSTOMER_ADMIN_USERNAME}"))
+                        runTest('customer-admin-permissions-test', parameters)
+
+                        testAdmin = "test-dedicated-admin"
+                        println "creating ${testAdmin} and adding it to the dedicated admins group"
+
+                        dir("htpasswd") {
+                            sh(
+                                returnStdout: false,
+                                script: """
+                                    oc login ${CLUSTER_URL} -u ${ADMIN_USERNAME} -p ${adminPassword} --insecure-skip-tls-verify
+                                    oc get secret htpasswd-secret -n openshift-config -o 'go-template={{index .data "htpasswd"}}' | base64 --decode > htpasswd
+                                    htpasswd -b htpasswd ${testAdmin} ${CUSTOMER_ADMIN_PASSWORD}
+                                    oc delete secret htpasswd-secret -n openshift-config
+                                    oc create secret generic htpasswd-secret --from-file=htpasswd=htpasswd -n openshift-config
+                                    sleep 75
+                                    oc adm groups add-users dedicated-admins ${testAdmin}
+                                    oc login ${CLUSTER_URL} -u ${testAdmin} -p ${CUSTOMER_ADMIN_PASSWORD} --insecure-skip-tls-verify # to 'enable' the user
+                                    oc login ${CLUSTER_URL} -u ${ADMIN_USERNAME} -p ${adminPassword} --insecure-skip-tls-verify
+                                    rm htpasswd
+                                """
+                            )
+
+                            // some time is needed to the new dedicated admin permissions propagation, hence the sleep time
+                            sleep time: 2, unit: 'MINUTES'
+
+                            testAdminParams = jobParams
+                            testAdminParams.add(string(name: 'CUSTOMER_ADMIN_USERNAME', value: "${testAdmin}"))
+                            runTest('customer-admin-permissions-test', testAdminParams)
+
+                            println "removing ${testAdmin} from the dedicated admins group"
+                            sh "oc adm groups remove-users dedicated-admins ${testAdmin}"
+
+                            // some time is needed for the test-dedicated-admin removal from dedicated-admins group propagation, hence the sleep time
+                            sleep time: 2, unit: 'MINUTES'
+
+                            runTest('customer-admin-permissions-test', testAdminParams)
+
+                            println "removing ${testAdmin} completely"
+                            sh(
+                                returnStdout: false,
+                                script: """
+                                    oc get secret htpasswd-secret -n openshift-config -o 'go-template={{index .data "htpasswd"}}' | base64 --decode > htpasswd
+                                    htpasswd -D htpasswd ${testAdmin}
+                                    oc delete secret htpasswd-secret -n openshift-config
+                                    oc create secret generic htpasswd-secret --from-file=htpasswd=htpasswd -n openshift-config
+                                    oc delete user ${testAdmin}
+                                    rm htpasswd
+                                """
+                            )
+                        }
+                    } // stage
+
+                } // node
+            }}} // timeout, ansiColor, timestamps
+        } catch (caughtError){
+            currentBuild.result = 'FAILURE'
+        }
+
+        def runTest(testPipeline, parameters) {
+            buildStatus = build(job: testPipeline, propagate: false, parameters: parameters).result
+            println "Build finished with ${buildStatus}"
+                            
+            if (buildStatus != 'SUCCESS') {
+                currentBuild.result = 'UNSTABLE'
+            }
+        }

--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -123,6 +123,7 @@ jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/ocp3/tower/tow
 #Integreatly-QE jobs - OpenShift 4 
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/ocp4/ocp4-install.yaml
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/ocp4/ocp4-testing-executor.yaml
+jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/integr8ly/ocp4/tests/ocp4-all-tests-executor.yaml
 
 #Views
 jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../views/repos/


### PR DESCRIPTION
## What
https://issues.jboss.org/browse/INTLY-3323 - added test stage to testing executor with running cust-adm perm tests

## Verification
The testing executor was successfully executed here: https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/OS4/job/ocp4-testing-executor/43/console

Test changes (to accommodate for testing admin belonging (and not) to dedicated-admin groups are here: https://gitlab.cee.redhat.com/integreatly-qe/integreatly-qe/merge_requests/270