### PR TITLE
changed default cleanup values to false

### DIFF
--- a/jobs/integr8ly/ocp4/ocp4-install.yaml
+++ b/jobs/integr8ly/ocp4/ocp4-install.yaml
@@ -58,11 +58,11 @@
             description: "Prefix of Integreatly Operator namespace, defauls to `BUILD_NUMBER`"
         - bool:
             name: CLEANUP_BEFOREHAND
-            default: true
+            default: false
             description: "Indicates whether to cleanup before execution"
         - bool:
             name: CLEANUP_AFTERWARD
-            default: true
+            default: false
             description: "Indicates whether to cleanup after execution"
         - string:
             name: NAMESPACE_CLEANUP_BEFOREHAND


### PR DESCRIPTION
## What
changed default cleanup values to false, so that nightly ocp4 pipeline is not affected by default removal of RHMI
