### PR TITLE
WIP: Add GA discovery job for Mobile Developer Console operator

### DIFF
--- a/jobs/delorean/folders.yaml
+++ b/jobs/delorean/folders.yaml
@@ -137,6 +137,17 @@
     display-name: 'GA'
     project-type: folder
 
+# MDC Operator
+- job:
+    name: delorean-mdc-operator
+    display-name: 'MDC Operator'
+    project-type: folder
+
+- job:
+    name: delorean-mdc-operator/ga
+    display-name: 'GA'
+    project-type: folder
+
 # Suites
 - job:
     name: delorean-suites

--- a/jobs/delorean/mdc-operator/ga/branch.yaml
+++ b/jobs/delorean/mdc-operator/ga/branch.yaml
@@ -1,0 +1,37 @@
+---
+- job:
+    name: delorean-mdc-operator/ga/branch
+    display-name: 'mdc-operator-ga-branch'
+    project-type: pipeline
+    concurrent: false
+    parameters:
+      - string:
+          name: 'installationGitUrl'
+          default: 'git@github.com:integr8ly/installation.git'
+          description: '[REQUIRED] The installation repo'
+      - string:
+          name: 'installationProductBranch'
+          default: 'mdc-operator-ga'
+          description: '[REQUIRED] The installation git branch to push new version changes'
+      - string:
+          name: 'productName'
+          default: 'mdc-operator'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
+      - string:
+          name: 'productVersionVar'
+          default: 'mdc_operator_release_tag'
+          description: '[REQUIRED] The manifest variable to be used as the current component version'
+          read-only: true
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
+    pipeline-scm:
+      script-path: jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
+      scm:
+        - git:
+            branches:
+              - master
+            url: 'https://github.com/integr8ly/ci-cd.git'
+            skip-tag: true
+            wipe-workspace: false

--- a/jobs/delorean/mdc-operator/ga/discovery.yaml
+++ b/jobs/delorean/mdc-operator/ga/discovery.yaml
@@ -19,7 +19,7 @@
           read-only: true
       - string:
           name: 'projectRepo'
-          default: 'mobile-security-service-operator'
+          default: 'mobile-developer-console-operator'
           description: '[REQUIRED] github project repository'
           read-only: true
       - string:

--- a/jobs/delorean/mdc-operator/ga/discovery.yaml
+++ b/jobs/delorean/mdc-operator/ga/discovery.yaml
@@ -1,0 +1,38 @@
+---
+- job:
+    name: delorean-mdc-operator/ga/discovery
+    display-name: 'mdc-operator-ga-discovery'
+    project-type: pipeline
+    concurrent: false
+    triggers:
+      - timed: '@daily'
+    parameters:
+      - string:
+          name: 'productVersionVar'
+          default: 'mdc_operator_release_tag'
+          description: '[REQUIRED] The manifest variable to be used as the current component version'
+          read-only: true
+      - string:
+          name: 'projectOrg'
+          default: 'aerogear'
+          description: '[REQUIRED] github project organization'
+          read-only: true
+      - string:
+          name: 'projectRepo'
+          default: 'mobile-security-service-operator'
+          description: '[REQUIRED] github project repository'
+          read-only: true
+      - string:
+          name: 'productName'
+          default: 'mdc-operator'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
+          read-only: true
+    pipeline-scm:
+      script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
+      scm:
+        - git:
+            branches:
+              - master
+            url: 'https://github.com/integr8ly/ci-cd.git'
+            skip-tag: true
+            wipe-workspace: false

--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -60,6 +60,7 @@ generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/suites/integration/ga/b
 generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/suites/integration/rc/branch.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/keycloak/ga/branch.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/keycloak/ga/discovery.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/mdc-operator/ga/discovery.yaml
 
 #OpenShift Cluster Jobs
 generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/create/openshift-cluster-create.yaml

--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -60,6 +60,7 @@ generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/suites/integration/ga/b
 generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/suites/integration/rc/branch.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/keycloak/ga/branch.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/keycloak/ga/discovery.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/mdc-operator/ga/branch.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/mdc-operator/ga/discovery.yaml
 
 #OpenShift Cluster Jobs


### PR DESCRIPTION
## What

This job will discover new releases of the mobile-developer-console-operator and automatically create the mdc-operator-ga branch in the Integreatly installer.

Because Aerogear is released together with Integreatly, we are not really discovering the latest GA version but we are discovering the latest tagged version.

For the above reason, I was still unsure if using the RC or the GA pipeline.

As for the MDC Operator, we will also add a discovery job for all other AeroGear projects in Integreatly.

Let me know if this is the correct approach

1. https://github.com/aerogear/mobile-developer-console-operator

<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->
