### PR TITLE
enabled concurrency in testing pipelines

### DIFF
--- a/jobs/integr8ly/ocp3/test-suites/after-first-login-tests.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/after-first-login-tests.yaml
@@ -5,6 +5,7 @@
     description: 'Executes backend-testsuite from integreatly qe repository on specified integreatly cluster'
     project-type: pipeline
     sandbox: true
+    concurrent: true
     parameters:
       - string:
           name: REPOSITORY

--- a/jobs/integr8ly/ocp3/test-suites/all-tests-executor.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/all-tests-executor.yaml
@@ -5,6 +5,7 @@
     project-type: pipeline
     description: "Pipeline to run all of the available integreatly tests"
     sandbox: true
+    concurrent: true
     properties:
       - build-discarder:
           num-to-keep: 20

--- a/jobs/integr8ly/ocp3/test-suites/browser-based-single-test.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/browser-based-single-test.yaml
@@ -5,6 +5,7 @@
     project-type: pipeline
     description: 'Executes browser based testsuite against Integreatly Tutorial Web App.'
     sandbox: true
+    concurrent: true
     parameters:
       - string:
           name: REPOSITORY

--- a/jobs/integr8ly/ocp3/test-suites/browser-based-testsuite-pipeline.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/browser-based-testsuite-pipeline.yaml
@@ -5,6 +5,7 @@
     project-type: pipeline
     description: 'Executes browser based testsuite against Integreatly Tutorial Web App.'
     sandbox: true
+    concurrent: true
     parameters:
       - string:
           name: REPOSITORY

--- a/jobs/integr8ly/ocp3/test-suites/installation-smoke-tests.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/installation-smoke-tests.yaml
@@ -4,6 +4,7 @@
     name: installation-smoke-tests
     project-type: pipeline
     sandbox: true
+    concurrent: true
     parameters:
       - string:
           name: REPOSITORY


### PR DESCRIPTION
## What
enabled concurrency in testing pipelines.

## Verification
Builds of two concurrently running browser tests (on the same cluster):
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Test%20Suites/job/browser-based-single-test/659/console && https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Test%20Suites/job/browser-based-single-test/660/console

I think some of the tests should still have the concurrency disabled in case, if somehow they are executed on the same cluster, hence only a couple of tests were changed