### PR TITLE
chore: add Delorean jobs for UPS and UPS Operator

### DIFF
--- a/jobs/delorean/folders.yaml
+++ b/jobs/delorean/folders.yaml
@@ -148,6 +148,28 @@
     display-name: 'GA'
     project-type: folder
 
+# UPS
+- job:
+    name: delorean-ups
+    display-name: 'UPS'
+    project-type: folder
+
+- job:
+    name: delorean-ups/ga
+    display-name: 'GA'
+    project-type: folder
+
+# UPS Operator
+- job:
+    name: delorean-ups-operator
+    display-name: 'UPS Operator'
+    project-type: folder
+
+- job:
+    name: delorean-ups-operator/ga
+    display-name: 'GA'
+    project-type: folder
+
 # Suites
 - job:
     name: delorean-suites

--- a/jobs/delorean/ups-operator/ga/branch.yaml
+++ b/jobs/delorean/ups-operator/ga/branch.yaml
@@ -1,0 +1,37 @@
+---
+- job:
+    name: delorean-ups-operator/ga/branch
+    display-name: 'ups-operator-ga-branch'
+    project-type: pipeline
+    concurrent: false
+    parameters:
+      - string:
+          name: 'installationGitUrl'
+          default: 'git@github.com:integr8ly/installation.git'
+          description: '[REQUIRED] The installation repo'
+      - string:
+          name: 'installationProductBranch'
+          default: 'ups-operator-ga'
+          description: '[REQUIRED] The installation git branch to push new version changes'
+      - string:
+          name: 'productName'
+          default: 'ups-operator'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
+      - string:
+          name: 'productVersionVar'
+          default: 'ups_operator_release_tag'
+          description: '[REQUIRED] The manifest variable to be used as the current component version'
+          read-only: true
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
+    pipeline-scm:
+      script-path: jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
+      scm:
+        - git:
+            branches:
+              - master
+            url: 'https://github.com/integr8ly/ci-cd.git'
+            skip-tag: true
+            wipe-workspace: false

--- a/jobs/delorean/ups-operator/ga/discovery.yaml
+++ b/jobs/delorean/ups-operator/ga/discovery.yaml
@@ -1,0 +1,38 @@
+---
+- job:
+    name: delorean-ups-operator/ga/discovery
+    display-name: 'ups-operator-ga-discovery'
+    project-type: pipeline
+    concurrent: false
+    triggers:
+      - timed: '@daily'
+    parameters:
+      - string:
+          name: 'productVersionVar'
+          default: 'ups_operator_release_tag'
+          description: '[REQUIRED] The manifest variable to be used as the current component version'
+          read-only: true
+      - string:
+          name: 'projectOrg'
+          default: 'aerogear'
+          description: '[REQUIRED] github project organization'
+          read-only: true
+      - string:
+          name: 'projectRepo'
+          default: 'unifiedpush-operator'
+          description: '[REQUIRED] github project repository'
+          read-only: true
+      - string:
+          name: 'productName'
+          default: 'ups-operator'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
+          read-only: true
+    pipeline-scm:
+      script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
+      scm:
+        - git:
+            branches:
+              - master
+            url: 'https://github.com/integr8ly/ci-cd.git'
+            skip-tag: true
+            wipe-workspace: false

--- a/jobs/delorean/ups/ga/branch.yaml
+++ b/jobs/delorean/ups/ga/branch.yaml
@@ -1,0 +1,37 @@
+---
+- job:
+    name: delorean-ups/ga/branch
+    display-name: 'ups-ga-branch'
+    project-type: pipeline
+    concurrent: false
+    parameters:
+      - string:
+          name: 'installationGitUrl'
+          default: 'git@github.com:integr8ly/installation.git'
+          description: '[REQUIRED] The installation repo'
+      - string:
+          name: 'installationProductBranch'
+          default: 'ups-ga'
+          description: '[REQUIRED] The installation git branch to push new version changes'
+      - string:
+          name: 'productName'
+          default: 'ups'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
+      - string:
+          name: 'productVersionVar'
+          default: 'ups_release_tag'
+          description: '[REQUIRED] The manifest variable to be used as the current component version'
+          read-only: true
+      - bool:
+          name: 'dryRun'
+          default: false
+          description: '[OPTIONAL][Test] Dry run only, only prints what it would do!'
+    pipeline-scm:
+      script-path: jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
+      scm:
+        - git:
+            branches:
+              - master
+            url: 'https://github.com/integr8ly/ci-cd.git'
+            skip-tag: true
+            wipe-workspace: false

--- a/jobs/delorean/ups/ga/discovery.yaml
+++ b/jobs/delorean/ups/ga/discovery.yaml
@@ -1,0 +1,38 @@
+---
+- job:
+    name: delorean-ups/ga/discovery
+    display-name: 'ups-ga-discovery'
+    project-type: pipeline
+    concurrent: false
+    triggers:
+      - timed: '@daily'
+    parameters:
+      - string:
+          name: 'productVersionVar'
+          default: 'ups_release_tag'
+          description: '[REQUIRED] The manifest variable to be used as the current component version'
+          read-only: true
+      - string:
+          name: 'projectOrg'
+          default: 'aerogear'
+          description: '[REQUIRED] github project organization'
+          read-only: true
+      - string:
+          name: 'projectRepo'
+          default: 'aerogear-unifiedpush-server'
+          description: '[REQUIRED] github project repository'
+          read-only: true
+      - string:
+          name: 'productName'
+          default: 'ups'
+          description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
+          read-only: true
+    pipeline-scm:
+      script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
+      scm:
+        - git:
+            branches:
+              - master
+            url: 'https://github.com/integr8ly/ci-cd.git'
+            skip-tag: true
+            wipe-workspace: false

--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -62,6 +62,10 @@ generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/keycloak/ga/branch.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/keycloak/ga/discovery.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/mdc-operator/ga/branch.yaml
 generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/mdc-operator/ga/discovery.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/ups/ga/branch.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/ups/ga/discovery.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/ups-operator/ga/branch.yaml
+generate_inline_script_job $SCRIPTS_DIR/../jobs/delorean/ups-operator/ga/discovery.yaml
 
 #OpenShift Cluster Jobs
 generate_inline_script_job $SCRIPTS_DIR/../jobs/openshift/cluster/create/openshift-cluster-create.yaml


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->
* Add branch job for ups
* Add discovery job for ups
* Add branch job for ups-operator
* Add discovery job for ups-operator
  > temporarily broken because the UPS operator doesn't use GitHub releases, but starting from the next release they will also use them

https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Delorean/job/delorean-ups/job/ga/
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Delorean/job/delorean-ups-operator/job/ga/