### PR TITLE
Using sudo in POC clean uninstall

### DIFF
--- a/jobs/integr8ly/ocp3/tower/tower-clean-uninstall.yaml
+++ b/jobs/integr8ly/ocp3/tower/tower-clean-uninstall.yaml
@@ -75,8 +75,8 @@
                             def masterIP = sh(
                                 returnStdout: true,
                                 script: """
-                                    oc login https://${clusterName}.${clusterDomainName} -u ${clusterAdminCredentials.clusterAdminUsername} -p ${clusterAdminCredentials.clusterAdminPassword} > /dev/null
-                                    oc describe node `oc get nodes | grep master | head -n 1 | awk '{print \$1}'` | grep ExternalIP | awk '{print \$2}'
+                                    sudo oc login https://${clusterName}.${clusterDomainName} -u ${clusterAdminCredentials.clusterAdminUsername} -p ${clusterAdminCredentials.clusterAdminPassword} > /dev/null
+                                    sudo oc describe node `oc get nodes | grep master | head -n 1 | awk '{print \$1}'` | grep ExternalIP | awk '{print \$2}'
                                 """).trim()
 
                             sh """
@@ -92,7 +92,7 @@
                         dir('installation') {
                             withCredentials([sshUserPrivateKey(credentialsId: 'tower-provisioner-pem', keyFileVariable: 'private_key')]){
                               sh """
-                                  ansible-playbook -i ./inventories/hosts --private-key ${private_key} ./playbooks/uninstall.yml
+                                  sudo ansible-playbook -i ./inventories/hosts --private-key ${private_key} ./playbooks/uninstall.yml
                               """
                             } // withCredentials
                         } // dir


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Using sudo to fix https://issues.jboss.org/browse/INTLY-3689.

Successful build:
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Nightly/job/tower-clean-uninstall/174/consoleFull
- I applied the changes manually, so search for 'sudo' in the build log to see it was indeed used.

Verification steps:
probably none, just eye review.