### PR TITLE
Added uninstallation branch parameter

### DIFF
--- a/jobs/integr8ly/ocp3/nightly/osd-testing-nightly-trigger.yaml
+++ b/jobs/integr8ly/ocp3/nightly/osd-testing-nightly-trigger.yaml
@@ -17,6 +17,7 @@
             CLUSTER_NAME=rhmi-qe1
             RECIPIENTS=integreatly-qe@redhat.com
             INSTALLATION_BRANCH=master
+            UNINSTALLATION_BRANCH=master
             ROUTER_SHARD=f2d1
             USERNAME=osdtester
             TEST_SUITES_REPOSITORY=https://gitlab.cee.redhat.com/integreatly-qe/integreatly-qe.git
@@ -46,12 +47,18 @@
                     currentBuild.description = "branch: ${INSTALLATION_BRANCH}"
 
                     stage ('Run uninstallation pipeline') {
+
+                        String uninstallationBranch = params.INSTALLATION_BRANCH
+                        if (params.UNINSTALLATION_BRANCH) {
+                            uninstallationBranch = params.UNINSTALLATION_BRANCH
+                        }
+
                         withCredentials([
                                 [$class: 'StringBinding', credentialsId: "rhmi-qe1-token", variable: 'OPENSHIFT_TOKEN']
                             ]) {
                             uninstallationStatus = build(job: 'osd-cluster-integreatly-uninstall', propagate: false, parameters: [
                                 string(name: 'clusterName', value: "${CLUSTER_NAME}"),
-                                string(name: 'uninstallationGitBranch', value: "${INSTALLATION_BRANCH}"),
+                                string(name: 'uninstallationGitBranch', value: "${uninstallationBranch}"),
                                 string(name: 'routerShard', value: "${ROUTER_SHARD}"),
                                 string(name: 'openShiftToken', value: "${OPENSHIFT_TOKEN}"),
                                 string(name: 'userName', value: "${USERNAME}")

--- a/jobs/integr8ly/ocp3/pds/pds-testing-executor.yaml
+++ b/jobs/integr8ly/ocp3/pds/pds-testing-executor.yaml
@@ -41,6 +41,9 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
             default: master
             description: "Branch of the installer repository"
         - string:
+            name: UNINSTALLATION_BRANCH
+            description: "Branch for the first uninstall. INSTALLATION_BRANCH used as default if left empty."
+        - string:
             name: TEST_SUITES_REPOSITORY
             default: https://gitlab.cee.redhat.com/integreatly-qe/integreatly-qe.git
             description: "Repository of the Integreatly test suites"
@@ -177,9 +180,15 @@ This needs to be changed to 'false' for Integreatly Workshop since it uses valid
 
         // Waiting for ${sleepTime} minutes so that resources scheduled for termination are actually terminated
         def uninstall(sleepTime) {
+
+            String uninstallationBranch = params.INSTALLATION_BRANCH
+            if (params.UNINSTALLATION_BRANCH) {
+                uninstallationBranch = params.UNINSTALLATION_BRANCH
+            }
+
             build job: 'pds-uninstall', parameters: [
                 string(name: 'REPOSITORY', value: "${INSTALLATION_REPOSITORY}"),
-                string(name: 'BRANCH', value: "${INSTALLATION_BRANCH}"),
+                string(name: 'BRANCH', value: "${uninstallationBranch}"),
                 string(name: 'ANSIBLE_USER', value: 'ec2-user'),
                 string(name: 'YOURCITY', value: "${YOURCITY}"),
                 string(name: 'CLUSTER_DOMAIN', value: "${CLUSTER_DOMAIN}"),


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Solves https://issues.jboss.org/browse/INTLY-1504. It enables you to specify different branch for uninstall and subsequent install. Useful for e.g upgrade testing if you need to uninstall 'master' and install latest GA for instance.

Build in Jenkins for PDS in progress:
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/PDS/job/pds-testing-executor/579/parameters/
but even now you can see that uninstall was triggered with 'master' (and not with release-1.5.2-rc1):
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/pds-uninstall/1283/parameters/

For OSD, I will probably trigger the pipeline too, but since it is the same piece of code this PR probably does not need to wait for that

Recreate pipelines successful build:
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Nightly/job/recreate-pipelines/280/consoleFull