### PR TITLE
Parameterize OSD pipelines with tower instance name

### DIFF
--- a/jobs/openshift/cluster/integreatly/osd-cluster-integreatly-install.yaml
+++ b/jobs/openshift/cluster/integreatly/osd-cluster-integreatly-install.yaml
@@ -64,6 +64,10 @@
       - string:
           name: 'clientSecret'
           description: '[REQUIRED] Desired client secret value for RHSSO'     
+      - string:
+          name: 'towerInstance'
+          default: 'Dev Tower'
+          description: '[REQUIRED] Name of a Tower instance from Ansible Tower plugin in Jenkins'      
     dsl: |
         node('cirhos_rhel7') {
           if (currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')['userId']){
@@ -73,7 +77,7 @@
           stage('Install Integreatly') {
             wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
                 ansibleTower(
-                  towerServer: 'Dev Tower',
+                  towerServer: "${towerInstance}",
                   jobTemplate: 'Integreatly_Bootstrap_and_Install_[OSD]',
                   templateType: 'workflow',
                   importTowerLogs: true,

--- a/jobs/openshift/cluster/integreatly/osd-cluster-integreatly-uninstall.yaml
+++ b/jobs/openshift/cluster/integreatly/osd-cluster-integreatly-uninstall.yaml
@@ -24,7 +24,11 @@
       - string:
           name: 'userName'
           default: 'tester'
-          description: '[REQUIRED] All existing users containing this string in their username will be removed.'    
+          description: '[REQUIRED] All existing users containing this string in their username will be removed.'
+      - string:
+          name: 'towerInstance'
+          default: 'Dev Tower'
+          description: '[REQUIRED] Name of a Tower instance from Ansible Tower plugin in Jenkins'         
     dsl: |
         node('cirhos_rhel7') {
           if (currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')['userId']){
@@ -34,7 +38,7 @@
           stage('Uninstall Integreatly') {
             wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
                 ansibleTower(
-                  towerServer: 'Dev Tower',
+                  towerServer: "${towerInstance}",
                   jobTemplate: 'Integreatly_Bootstrap_and_Uninstall_[OSD]',
                   templateType: 'workflow',
                   importTowerLogs: true,

--- a/jobs/openshift/cluster/integreatly/osd-cluster-integreatly-upgrade.yaml
+++ b/jobs/openshift/cluster/integreatly/osd-cluster-integreatly-upgrade.yaml
@@ -21,6 +21,10 @@
           name: 'openShiftToken'
           default: ''
           description: '[REQUIRED] Openshift token for cluster-admin user'
+      - string:
+          name: 'towerInstance'
+          default: 'Dev Tower'
+          description: '[REQUIRED] Name of a Tower instance from Ansible Tower plugin in Jenkins'     
     dsl: |
         node('cirhos_rhel7') {
           if (currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')['userId']){
@@ -30,7 +34,7 @@
           stage('Upgrade Integreatly') {
             wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
                 ansibleTower(
-                  towerServer: 'Dev Tower',
+                  towerServer: "${towerInstance}",
                   jobTemplate: 'Integreatly_Bootstrap_and_Upgrade_[OSD]',
                   templateType: 'workflow',
                   importTowerLogs: true,


### PR DESCRIPTION
There is the option to have multiple tower instances configured in Jenkins. We temporarily need to have 2 instances connected/configured. That's why we parameterize that. 

`Dev Tower` is "old" common cicd instance.
`Temp Tower` is the newer one used only for 1.5.2 testing. 
