### PR TITLE
Renaming Cluster Management Workflow Jobs

### DIFF
--- a/docs/delorean/automated-tests.md
+++ b/docs/delorean/automated-tests.md
@@ -39,7 +39,7 @@ This pipeline is split into the following stages:
 
     Once all the tests has been executed, the pipeline `OpenShift Cluster Integreatly Uninstall` gets built. This uninstalls the Integreatly environment from the provisioned PoC cluster. For more information about this pipeline, see the [deprovisionig PoC clusters](./cluster-management#uninstalling-integreatly) documentation.
 
-5. **Deprovision Cluster**
+5. **Cluster Deprovision**
 
     This stage will always get called in order to cleanup any resources the previous stages has created. It calls the pipeline `OpenShift Cluster Deprovision` which tears down the PoC cluster created in stage 1. For more information about this pipeline, see the [](./cluster-management#deprovisioning-poc-clusters) documentation.
 

--- a/docs/delorean/cluster-management.md
+++ b/docs/delorean/cluster-management.md
@@ -22,7 +22,7 @@ The Delorean cluster management sends requests to Ansible Tower to launch workfl
 ## Creating PoC Clusters
 PoC clusters can be provisioned by building the `Openshift Cluster Create` pipeline which is defined in the [jobs/openshift/cluster/create/](../../jobs/openshift/cluster/create/) directory.
 
-This pipeline launches the `Provision Cluster` workflow in Ansible Tower. For more information about this workflow, see the [cluster create](https://github.com/integr8ly/ansible-tower-configuration#46-cluster-create) documentation.
+This pipeline launches the `Cluster Provision` workflow in Ansible Tower. For more information about this workflow, see the [cluster create](https://github.com/integr8ly/ansible-tower-configuration#45-cluster-create) documentation.
 
 To run this pipeline on Jenkins:
 1. Go to the `OpenShift` tab
@@ -138,7 +138,7 @@ To run this pipeline on Jenkins:
 ## Deprovisioning PoC Clusters
 PoC clusters can be deprovisioned by building the `Openshift Cluster Deprovision` pipeline which is defined in the [jobs/openshift/cluster/deprovision/](../../jobs/openshift/cluster/deprovision/) directory.
 
-This pipeline launches the `Deprovision Cluster` workflow in Ansible Tower. For more information about this workflow, see the [cluster deprovision](https://github.com/integr8ly/ansible-tower-configuration#47-cluster-deprovision) documentation.
+This pipeline launches the `Cluster Deprovision` workflow in Ansible Tower. For more information about this workflow, see the [cluster deprovision](https://github.com/integr8ly/ansible-tower-configuration#46-cluster-deprovision) documentation.
 
 To run this pipeline on Jenkins:
 1. Go to the `OpenShift` tab

--- a/jobs/openshift/cluster/create/Jenkinsfile
+++ b/jobs/openshift/cluster/create/Jenkinsfile
@@ -76,7 +76,7 @@ node('cirhos_rhel7') {
             wrap([$class: 'AnsiColorBuildWrapper', colorMapName: 'xterm']) {
                 ansibleTower(
                         towerServer: 'Dev Tower',
-                        jobTemplate: 'Provision Cluster',
+                        jobTemplate: 'Cluster Provision',
                         templateType: 'workflow',
                         importTowerLogs: true,
                         removeColor: false,

--- a/jobs/openshift/cluster/deprovision/Jenkinsfile
+++ b/jobs/openshift/cluster/deprovision/Jenkinsfile
@@ -39,13 +39,13 @@ node('cirhos_rhel7') {
   cleanWs()
   stage('Deprovision OpenShift Cluster') {
     if (params.dryRun) {
-      println("""Would trigger the job 'Deprovision Cluster' in ansibleTower with the following parameters:
+      println("""Would trigger the job 'Cluster Deprovision' in ansibleTower with the following parameters:
                 \naws_cluster_name: ${deprovisionOptions.clusterName}, aws_region: ${deprovisionOptions.awsRegion}, cluster_credential_bundle_aws_name: ${deprovisionOptions.awsAccountName}, aws_dns_zone: ${deprovisionOptions.clusterDomainName}""")
     } else {
       wrap([$class: 'AnsiColorBuildWrapper', colorMapName: "xterm"]) {
         ansibleTower(
           towerServer: 'Dev Tower',
-          jobTemplate: 'Deprovision Cluster',
+          jobTemplate: 'Cluster Deprovision',
           templateType: 'workflow',
           importTowerLogs: true,
           removeColor: false,


### PR DESCRIPTION
## What
Renaming Cluster Management jobs to reflect latest Tower Configurations

## Changes
Renamed `Provision Cluster` to `Cluster Provision`
Renamed `Deprovision Cluster` to `Cluster Deprovision`