### PR TITLE
Setting correct cred name for openshift cluster create job

### DIFF
--- a/jobs/openshift/cluster/create/Jenkinsfile
+++ b/jobs/openshift/cluster/create/Jenkinsfile
@@ -4,7 +4,7 @@ def clusterOptions = [:]
 
 def verifyClusterOptions(clusterOptions) {
     if (!clusterOptions.name || !clusterOptions.awsRegion || !clusterOptions.awsAccountName) {
-        choiceAWSAccountName = new ChoiceParameterDefinition('awsAccountName', ['fheng'] as String[], 'AWS Account Name')
+        choiceAWSAccountName = new ChoiceParameterDefinition('awsAccountName', ['fheng.AWS'] as String[], 'AWS Account Name')
         def userInput = input message: 'Cluster Options', parameters: [
                 string(defaultValue: (clusterOptions.name ?: ''), description: 'Cluster name', name: 'clusterName'),
                 string(defaultValue: (clusterOptions.awsRegion ?: 'eu-west-2'), description: 'AWS Region', name: 'awsRegion'),

--- a/jobs/openshift/cluster/create/openshift-cluster-create.yaml
+++ b/jobs/openshift/cluster/create/openshift-cluster-create.yaml
@@ -20,7 +20,7 @@
       - choice:
           name: 'awsAccountName'
           choices:
-            - fheng
+            - fheng.AWS
           description: '[REQUIRED] The AWS Account to use'
       - bool:
           name: 'dryRun'


### PR DESCRIPTION
## What
Openshift Cluster Create job has an incorrect credential name set resulting in failed builds against Tower.

## Validation
I've already manually added this to QE Jenkins and confirm that it is now working as expected, see https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/OpenShift/job/openshift-cluster-create/968/