### PR TITLE
Switching on the POC nightly pipelines

### DIFF
--- a/jobs/integr8ly/ocp3/delorean-testing-nightly-trigger.yaml
+++ b/jobs/integr8ly/ocp3/delorean-testing-nightly-trigger.yaml
@@ -6,7 +6,7 @@
     description: "Nightly pipeline trigger for Delorean testing."
     sandbox: false
     concurrent: false
-    disabled: true
+    disabled: false
     triggers:
       - timed: "H(0-10) 18 * * *"
     properties:

--- a/jobs/integr8ly/ocp3/test-suites/msb-integration-test.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/msb-integration-test.yaml
@@ -4,7 +4,7 @@
     display-name: 'Managed Service Broker Integration Test'
     project-type: pipeline
     concurrent: false
-    disabled: true
+    disabled: false
     triggers:
       - timed: "H(0-10) 23 * * *"
     properties:

--- a/jobs/integr8ly/ocp3/tower/tower-clean-uninstall.yaml
+++ b/jobs/integr8ly/ocp3/tower/tower-clean-uninstall.yaml
@@ -6,7 +6,7 @@
     project-type: pipeline
     sandbox: false
     concurrent: false
-    disabled: true
+    disabled: false
     properties:
       - build-discarder:
           num-to-keep: 20


### PR DESCRIPTION
## What
Enabled the following nightly pipelines
1.  Delorean-testing-nightly-trigger
2. msb-integration-test
3. tower-clean-uninstall
