### PR TITLE
Removed patching of Grafana operator

### DIFF
--- a/jobs/integr8ly/ocp3/pds/pds-install.yaml
+++ b/jobs/integr8ly/ocp3/pds/pds-install.yaml
@@ -244,9 +244,11 @@
                                 sudo oc patch deploymentconfig/tutorial-web-app -n ${NAMESPACE_PREFIX}webapp -p '{ "spec": { "template": { "spec": { "containers": [{ "name": "tutorial-web-app", "image": "quay.io/integreatly/tutorial-web-app:master" }]}}}}' || true
                                 
                                 # patch grafana-operator to use master tag
-                                sudo oc scale --replicas=0 deployment grafana-operator -n ${NAMESPACE_PREFIX}middleware-monitoring
-                                sudo oc patch deployment grafana-operator -n ${NAMESPACE_PREFIX}middleware-monitoring -p  '{ "spec": { "template": { "spec": { "containers": [{ "name": "grafana-operator", "image": "quay.io/integreatly/grafana-operator:master" }]}}}}'
-                                sudo oc scale --replicas=1 deployment grafana-operator -n ${NAMESPACE_PREFIX}middleware-monitoring
+                                # Commented out. The master branch of Grafana operator now contains modifications for OCPv4. We can't just use master anymore on OCPv3
+                                # 
+                                # sudo oc scale --replicas=0 deployment grafana-operator -n ${NAMESPACE_PREFIX}middleware-monitoring
+                                # sudo oc patch deployment grafana-operator -n ${NAMESPACE_PREFIX}middleware-monitoring -p  '{ "spec": { "template": { "spec": { "containers": [{ "name": "grafana-operator", "image": "quay.io/integreatly/grafana-operator:master" }]}}}}'
+                                # sudo oc scale --replicas=1 deployment grafana-operator -n ${NAMESPACE_PREFIX}middleware-monitoring
                                 
                                 # patch application-monitoring-operator to use master tag
                                 sudo oc scale --replicas=0 deployment application-monitoring-operator -n ${NAMESPACE_PREFIX}middleware-monitoring


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

We cannot use the master branch of Grafana operator anymore since this branch contains pieces for OCPv4 now. After a lengthy conversation with DavidM it seems this is indeed the only easy and simple solution. The latest Grafana operator version for OCPv3 is v1.3.1.

Not sure what happens if some other modifications for OCPv3 are required. Probably branch from v1.3.1 will be created for that. We'll see I guess. I only commented the bit out since I still hope we get to pathing again at some point.