### PR TITLE
DeLorean branch job updates

### DIFF
--- a/jobs/delorean/3scale/ga/branch.yaml
+++ b/jobs/delorean/3scale/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: '3scale-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: '3scale'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/amq-online/ga/branch.yaml
+++ b/jobs/delorean/amq-online/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'amq-online-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'amq-online'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/backup-container/ga/branch.yaml
+++ b/jobs/delorean/backup-container/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'backup-container-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'backup-container'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'

--- a/jobs/delorean/codeready/ga/branch.yaml
+++ b/jobs/delorean/codeready/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'codeready-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'codeready'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/datasync-template/ga/branch.yaml
+++ b/jobs/delorean/datasync-template/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'datasync-template-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'datasync-template'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/fuse-online/ga/branch.yaml
+++ b/jobs/delorean/fuse-online/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'fuse-online-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'fuse-online'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/fuse-online/rc/branch.yaml
+++ b/jobs/delorean/fuse-online/rc/branch.yaml
@@ -13,6 +13,10 @@
           name: 'installationProductBranch'
           default: 'fuse-online-rc'
           description: '[REQUIRED] The installation git branch to push new version changes'
+      - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
       - bool:
           name: 'dryRun'
           default: false

--- a/jobs/delorean/fuse/ga/branch.yaml
+++ b/jobs/delorean/fuse/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'fuse-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'fuse'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/gitea/ga/branch.yaml
+++ b/jobs/delorean/gitea/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'gitea-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'gitea'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/branch/ga/Jenkinsfile
@@ -18,7 +18,7 @@ def createJiraQuery(labels) {
   return query
 }
 
-def createJiraBody(summary, gitPrUrl, labels) {
+def createJiraBody(summary, description, gitPrUrl, labels) {
   return """{
       "fields": {
           "project": {
@@ -27,7 +27,7 @@ def createJiraBody(summary, gitPrUrl, labels) {
               "name": "Integreatly"
           },
           "summary": "${summary}",
-          "description": "${gitPrUrl}",
+          "description": "${description}",
           "labels": ${labels},
           "issuetype": {
               "name": "Task"
@@ -45,7 +45,7 @@ def ghOwner = "integr8ly"
 def ghRepo = "installation"
 def installationGitUrl = params.installationGitUrl ?: 'git@github.com:integr8ly/installation.git'
 def sourceBranch = params.installationProductBranch
-def targetBranch = 'master'
+def targetBranch = params.installationTargetBranch ?: 'master'
 def githubSSHCredentialsID = 'jenkinsgithub'
 def githubUserPassCredentialsID = 'githubjenkins'
 def productName = params.productName
@@ -61,6 +61,31 @@ def productVersion
 String[] defaultPRLabels = ["product update", productName]
 def installationManifestFile = './inventories/group_vars/all/manifest.yaml'
 String jiraRestApiUrl = "https://issues.jboss.org/rest/api/2"
+
+currentBuild.description = "sourceBranch: ${sourceBranch}\n targetBranch: ${targetBranch}"
+
+String[] jiraLabelsFor(String productName, String targetBranch, def labels = []) {
+    def defaultLabels = [
+            /"unplanned"/,
+            /"${productName}"/
+    ]
+    if('master' != targetBranch) {
+        labels << /"${targetBranch}"/
+    }
+    return labels + defaultLabels
+}
+
+String jiraSummaryFor(String productName, String targetBranch) {
+    String summary = "Update ${productName} "
+    if('master' != targetBranch) {
+        summary = summary + "(${targetBranch})"
+    }
+    return summary
+}
+
+String jiraDescriptionFor(String productName, String targetBranch, String prUrl) {
+    return "Update of ${productName} is availabe to go back to ${targetBranch}. PR: ${prUrl}"
+}
 
 node {
     cleanWs()
@@ -102,38 +127,13 @@ node {
         }
     }
 
-    stage('Create Jira Update Issue') {
+    stage('Create Product Update Jira') {
         when(sourceChanges) {
-            String[] labels = [
-              /"product-update"/,
-              /"${productName}"/
-            ]
-            String summary = "Update ${productName}"
-
+            String[] labels = jiraLabelsFor(productName, targetBranch, [/"product-update"/])
+            String summary = jiraSummaryFor(productName, targetBranch)
+            String description = jiraDescriptionFor(productName, targetBranch, prUrl)
             String query = createJiraQuery(labels)
-            def body = createJiraBody(summary, prUrl, labels)
-
-            def jiraID = jiraCreateIssue(jiraUserPass, jiraRestApiUrl, query, body)
-            println "[INFO] Issue created: https://issues.jboss.org/browse/${jiraID}"
-        }
-    }
-
-    stage('Create Jira Upgrade Issue') {
-        when(sourceChanges) {
-            dir('installation') {
-                sh "git checkout ${targetBranch}"
-                currentProductVersion = getProductVersionFromManifest(productVersionVar, installationManifestFile)
-            }
-
-            String[] labels = [
-              /"product-upgrade"/,
-              /"${productName}"/
-            ]
-            String summary = "Add upgrade sop or playbook for ${productName}"
-
-            String query = createJiraQuery(labels)
-            def body = createJiraBody(summary, prUrl, labels)
-            
+            def body = createJiraBody(summary, description, prUrl, labels)
             def jiraID = jiraCreateIssue(jiraUserPass, jiraRestApiUrl, query, body)
             println "[INFO] Issue created: https://issues.jboss.org/browse/${jiraID}"
         }

--- a/jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
@@ -204,7 +204,7 @@ node() {
         dir('installation') {
             latestRHMIRelease = sh(returnStdout: true, script: "git describe --tags `git rev-list --tags --max-count=1`")
             latestRHMIBranch = getRHMIReleaseBranch(latestRHMIRelease)
-            latestReleaseGABranch = "${gaBranch}-${latestRHMIBranch}"
+            latestReleaseGABranch = "${gaBranch}_${latestRHMIBranch}"
         }
         println "[INFO] Latest RHMI Release latestRHMIRelease:${latestRHMIRelease}, latestRHMIBranch:${latestRHMIBranch}, latestReleaseGABranch:${latestReleaseGABranch}"
     }

--- a/jobs/delorean/job-templates/ga/branch.yaml
+++ b/jobs/delorean/job-templates/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: '<product-name>-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: '<product-name>'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/mdc-operator/ga/branch.yaml
+++ b/jobs/delorean/mdc-operator/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'mdc-operator-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'mdc-operator'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/mdc/ga/branch.yaml
+++ b/jobs/delorean/mdc/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'mdc-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'mdc'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/middleware-monitoring/ga/branch.yaml
+++ b/jobs/delorean/middleware-monitoring/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'middleware-monitoring-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'middleware-monitoring'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/misc/github-events/Jenkinsfile
+++ b/jobs/delorean/misc/github-events/Jenkinsfile
@@ -1,19 +1,11 @@
 #!groovy
 @Library('delorean-pipeline-library') _
 
-import org.kohsuke.github.GHCommitState
-import org.kohsuke.github.GHPullRequest
-import org.kohsuke.github.GitHub
-import org.kohsuke.github.GitHubBuilder
-
-def ghUtils = new org.integr8ly.GitHubUtils()
-
 String githubEventStr = params.sqs_body
 String gitBranch = ""
 String prUrl = ""
-
-String githubUserPassCredentialsID = "githubjenkins"
-final String ghCommitStatusContext = 'delorean/integration-tests'
+def productAndType
+String targetBranch = ""
 
 currentBuild.description = "sqsMessageId: ${params.sqs_messageId}"
 
@@ -25,7 +17,7 @@ node {
         if (ghEvent.eventType == "push") {
             gitBranch = ghEvent['ref'].tokenize('/').last()
             currentBuild.description = "${currentBuild.description}\nevent: push\nbranch: ${gitBranch}"
-        } 
+        }
 
         if (ghEvent.eventType == "pull_request") {
             def pullRequest = ghEvent.pull_request
@@ -34,15 +26,25 @@ node {
 
             currentBuild.description = "${currentBuild.description}\nevent: pull_request\nbranch: ${gitBranch}\npr: ${prUrl}"
         }
+
+        def branchParts = gitBranch.split('_') as List
+        productAndType = branchParts[0]
+        targetBranch = branchParts[1] ?: 'master'
+        println "branch: $gitBranch, productAndType:$productAndType, targetBranch:$targetBranch"
     }
 
     stage('Trigger branch job') {
-        when(gitBranch.endsWith("-ga") || gitBranch.endsWith("-rc") || gitBranch.endsWith("-latest")) {
-            println "Run branch job for ${productName}/${branchType}"
-            def branchType = gitBranch.split("-").last()
-            def productName = gitBranch.minus("-${branchType}")
+        when(productAndType.endsWith("-ga") || productAndType.endsWith("-rc") || productAndType.endsWith("-latest")) {
+            def branchType = productAndType.split("-").last()
+            def productName = productAndType.minus("-${branchType}")
+            println "Delorean branch($branch), run branch job for ${productName}/${branchType}"
             def jobName = "delorean-${productName}/${branchType}/branch"
-            build job: jobName, wait: false
+            def jobParams = [
+                    [$class: 'StringParameterValue', name: 'installationProductBranch', value: gitBranch],
+                    [$class: 'StringParameterValue', name: 'installationTargetBranch', value: targetBranch]
+            ]
+            println "jobName:$jobName, jobParams:$jobParams"
+            build job: jobName, parameters: jobParams, wait: false
         }
     }
 }

--- a/jobs/delorean/mobile-walkthrough/ga/branch.yaml
+++ b/jobs/delorean/mobile-walkthrough/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'mobile-walkthrough-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'mobile-walkthrough'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/msbroker/ga/branch.yaml
+++ b/jobs/delorean/msbroker/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'msbroker-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'msbroker'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/mss-operator/ga/branch.yaml
+++ b/jobs/delorean/mss-operator/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'mss-operator-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'mss-operator'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/mss/ga/branch.yaml
+++ b/jobs/delorean/mss/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'mss-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'mss'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/rhsso/ga/branch.yaml
+++ b/jobs/delorean/rhsso/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'rhsso-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'rhsso'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/ups-operator/ga/branch.yaml
+++ b/jobs/delorean/ups-operator/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'ups-operator-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'ups-operator'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/ups/ga/branch.yaml
+++ b/jobs/delorean/ups/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'ups-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'ups'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'

--- a/jobs/delorean/webapp/ga/branch.yaml
+++ b/jobs/delorean/webapp/ga/branch.yaml
@@ -14,6 +14,10 @@
           default: 'webapp-ga'
           description: '[REQUIRED] The installation git branch to push new version changes'
       - string:
+          name: 'installationTargetBranch'
+          default: 'master'
+          description: '[REQUIRED] The installation git branch to target'
+      - string:
           name: 'productName'
           default: 'webapp'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'


### PR DESCRIPTION
Changes to allow the branch job to execute on both changes back to master and the previous release branch (v1.5)

* Update GH event handler to parse target branch
* Update branch jobs to take installationTargetBranch as a parameter
* Add unplanned label to all jiras created and remove "product-upgrade" jira creation.

Jira: https://issues.jboss.org/browse/INTLY-3933
