### PR TITLE
Enable concurrency for OSD pipelines

### DIFF
--- a/jobs/openshift/cluster/integreatly/osd-cluster-integreatly-install.yaml
+++ b/jobs/openshift/cluster/integreatly/osd-cluster-integreatly-install.yaml
@@ -3,7 +3,7 @@
     name: osd-cluster-integreatly-install
     display-name: 'OSD Cluster Integreatly Install'
     project-type: pipeline
-    concurrent: false
+    concurrent: true
     parameters:
       - string:
           name: 'clusterName'

--- a/jobs/openshift/cluster/integreatly/osd-cluster-integreatly-uninstall.yaml
+++ b/jobs/openshift/cluster/integreatly/osd-cluster-integreatly-uninstall.yaml
@@ -3,7 +3,7 @@
     name: osd-cluster-integreatly-uninstall
     display-name: 'OSD Cluster Integreatly Uninstall'
     project-type: pipeline
-    concurrent: false
+    concurrent: true
     parameters:
       - string:
           name: 'clusterName'

--- a/jobs/openshift/cluster/integreatly/osd-cluster-integreatly-upgrade.yaml
+++ b/jobs/openshift/cluster/integreatly/osd-cluster-integreatly-upgrade.yaml
@@ -3,7 +3,7 @@
     name: osd-cluster-integreatly-upgrade
     display-name: 'OSD Cluster Integreatly Upgrade'
     project-type: pipeline
-    concurrent: false
+    concurrent: true
     parameters:
       - string:
           name: 'clusterName'


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

New cicd tower supports job concurrency. We can allow concurrent builds for OSD pipelines.

Verification Steps
Probably just eye review.

Successful build of recreate-pipelines:
https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Nightly/job/recreate-pipelines/299/