### PR TITLE
fixed populating incorrect values to installation CR during olm installation

### DIFF
--- a/jobs/integr8ly/ocp4/install/Jenkinsfile
+++ b/jobs/integr8ly/ocp4/install/Jenkinsfile
@@ -11,10 +11,6 @@ node('cirhos_rhel7') {
     timeout(75) { ansiColor('gnome-terminal') { timestamps {
         try {
             currentBuild.displayName = "${currentBuild.displayName} ${CLUSTER_NAME}"
-            stage('Login to OpenShift 4 cluster') {
-
-                sh "oc login ${clusterAPI} --insecure-skip-tls-verify=true -u ${ADMIN_USERNAME} -p ${ADMIN_PASSWORD}"
-            } // stage
 
             stage('Install RHMI') {
                 dir('integreatly-operator') {
@@ -26,6 +22,8 @@ node('cirhos_rhel7') {
                         userRemoteConfigs: [[url: INTEGREATLY_OPERATOR_REPOSITORY]]
                     ])
 
+                    sh "git clean -xdf"
+                    sh "oc login ${clusterAPI} --insecure-skip-tls-verify=true -u ${ADMIN_USERNAME} -p ${ADMIN_PASSWORD}"
                     sh "make test/e2e/olm"
                 } // dir
             } // stage                 


### PR DESCRIPTION
## What
fixed populating incorrect values to installation CR during olm installation

## Verification
Check the output of those two pipeline builds:

https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/OS4/job/openshift4-rhmi-install/2/console

and 

https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/OS4/job/openshift4-rhmi-install/4/console
