### PR TITLE
Optionally update the current RHMI release on patch upgrades

### DIFF
--- a/jobs/delorean/3scale/ga/discovery.yaml
+++ b/jobs/delorean/3scale/ga/discovery.yaml
@@ -27,6 +27,10 @@
           default: '3scale'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/amq-online/ga/discovery.yaml
+++ b/jobs/delorean/amq-online/ga/discovery.yaml
@@ -36,6 +36,10 @@
           name: 'gaReleaseTagRef'
           default: 'GA'
           description: '[REQUIRED] Reference used to filter GA releases from the repository tags'
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/backup-container/ga/discovery.yaml
+++ b/jobs/delorean/backup-container/ga/discovery.yaml
@@ -27,6 +27,10 @@
           default: 'backup-container'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version if available'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/codeready/ga/discovery.yaml
+++ b/jobs/delorean/codeready/ga/discovery.yaml
@@ -37,6 +37,10 @@
           default: 'GA'
           description: '[REQUIRED] Reference used to filter GA releases from the repository tags'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/datasync-template/ga/discovery.yaml
+++ b/jobs/delorean/datasync-template/ga/discovery.yaml
@@ -27,6 +27,10 @@
           default: 'datasync-template'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/fuse-online/ga/discovery.yaml
+++ b/jobs/delorean/fuse-online/ga/discovery.yaml
@@ -42,6 +42,10 @@
           default: 'tag'
           description: '[REQUIRED] Method to fetch latest release which can either be by tag or by release'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/fuse/ga/discovery.yaml
+++ b/jobs/delorean/fuse/ga/discovery.yaml
@@ -37,6 +37,10 @@
           default: 'redhat'
           description: '[REQUIRED] Reference used to filter GA releases from the repository tags'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/gitea/ga/discovery.yaml
+++ b/jobs/delorean/gitea/ga/discovery.yaml
@@ -42,6 +42,10 @@
           default: 'GiteaVersion'
           description: '[OPTIONAL] Identifier to be used to retrieve the product version from the productVersionLocation'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
@@ -13,6 +13,7 @@ def productName = params.productName
 def releaseFetchMethod = params.releaseFetchMethod
 def gaBranch = params.installationProductBranch ?: "${productName}-ga"
 def gaReleaseTagRef = params.gaReleaseTagRef ?: ''
+boolean updateLatestRHMIRelease = params.updateLatestRHMIRelease ?: false
 
 def latestRHMIRelease
 String latestRHMIBranch
@@ -220,7 +221,7 @@ def processInstallationBranch(body) {
 
             stage("Update Manifest File (${branch})") {
                 println "[INFO] Product Version Update (${branch})"
-                if(latestProductRelease != currentProductRelease) {
+                if (latestProductRelease != currentProductRelease) {
                     gitCommitWhenChanges("Updated ${product} product version to ${latestProductRelease}") { msgs ->
                         def manifestFileTxt = readFile(installationManifestFile)
                         manifestFileTxt = updateManifestVariable(manifestFileTxt, releaseTagVar, latestProductRelease)
@@ -232,7 +233,7 @@ def processInstallationBranch(body) {
 
             stage("Update Upgrade File (${branch})") {
                 println "[INFO] Product Upgrade Update (${branch})"
-                if(latestProductRelease != currentProductRelease) {
+                if (latestProductRelease != currentProductRelease) {
                     def exists = fileExists installationUpgradeFile
                     if (exists) {
                         gitCommitWhenChanges("Add ${product} to update products list") { msgs ->
@@ -290,16 +291,6 @@ node() {
         println "[INFO] Latest Product Release = ${latestReleases}"
     }
 
-    stage('Fetch Latest RHMI Release') {
-        gitCheckoutRepo(installationGitUrl, 'master', githubSSHCredentialsID, 'installation')
-        dir('installation') {
-            latestRHMIRelease = sh(returnStdout: true, script: "git describe --tags `git rev-list --tags --max-count=1`")
-            latestRHMIBranch = getRHMIReleaseBranch(latestRHMIRelease)
-            latestReleaseGABranch = "${gaBranch}_${latestRHMIBranch}"
-        }
-        println "[INFO] Latest RHMI Release latestRHMIRelease:${latestRHMIRelease}, latestRHMIBranch:${latestRHMIBranch}, latestReleaseGABranch:${latestReleaseGABranch}"
-    }
-
     processInstallationBranch {
         branch = gaBranch
         baseBranch = installationGitRef
@@ -309,12 +300,25 @@ node() {
         updateVersionType = 'ga'
     }
 
-    processInstallationBranch {
-        branch = latestReleaseGABranch
-        baseBranch = latestRHMIBranch
-        product = productName
-        latestProductReleases = latestReleases
-        updateVersionLevels = ['patch']
-        updateVersionType = 'ga'
+    if (updateLatestRHMIRelease) {
+
+        stage('Fetch Latest RHMI Release') {
+            gitCheckoutRepo(installationGitUrl, 'master', githubSSHCredentialsID, 'installation')
+            dir('installation') {
+                latestRHMIRelease = sh(returnStdout: true, script: "git describe --tags `git rev-list --tags --max-count=1`")
+                latestRHMIBranch = getRHMIReleaseBranch(latestRHMIRelease)
+                latestReleaseGABranch = "${gaBranch}_${latestRHMIBranch}"
+            }
+            println "[INFO] Latest RHMI Release latestRHMIRelease:${latestRHMIRelease}, latestRHMIBranch:${latestRHMIBranch}, latestReleaseGABranch:${latestReleaseGABranch}"
+        }
+
+        processInstallationBranch {
+            branch = latestReleaseGABranch
+            baseBranch = latestRHMIBranch
+            product = productName
+            latestProductReleases = latestReleases
+            updateVersionLevels = ['patch']
+            updateVersionType = 'ga'
+        }
     }
 }

--- a/jobs/delorean/keycloak/ga/discovery.yaml
+++ b/jobs/delorean/keycloak/ga/discovery.yaml
@@ -49,6 +49,10 @@
           default: 'GA'
           description: '[REQUIRED] Reference used to filter GA releases from the repository tags'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/mdc-operator/ga/discovery.yaml
+++ b/jobs/delorean/mdc-operator/ga/discovery.yaml
@@ -27,6 +27,10 @@
           default: 'mdc-operator'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/mdc/ga/discovery.yaml
+++ b/jobs/delorean/mdc/ga/discovery.yaml
@@ -27,6 +27,10 @@
           default: 'mdc'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/middleware-monitoring/ga/discovery.yaml
+++ b/jobs/delorean/middleware-monitoring/ga/discovery.yaml
@@ -27,6 +27,10 @@
           default: 'middleware-monitoring'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/mobile-walkthrough/ga/discovery.yaml
+++ b/jobs/delorean/mobile-walkthrough/ga/discovery.yaml
@@ -27,6 +27,10 @@
           default: 'mobile-walkthrough'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/msbroker/ga/discovery.yaml
+++ b/jobs/delorean/msbroker/ga/discovery.yaml
@@ -27,6 +27,10 @@
           default: 'msbroker'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/mss-operator/ga/discovery.yaml
+++ b/jobs/delorean/mss-operator/ga/discovery.yaml
@@ -27,6 +27,10 @@
           default: 'mss-operator'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/mss/ga/discovery.yaml
+++ b/jobs/delorean/mss/ga/discovery.yaml
@@ -27,6 +27,10 @@
           default: 'mss'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/rhsso/ga/discovery.yaml
+++ b/jobs/delorean/rhsso/ga/discovery.yaml
@@ -42,6 +42,10 @@
           default: 'SSO_VERSION'
           description: '[OPTIONAL] Identifier to be used to retrieve the product version from the productVersionLocation'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/ups-operator/ga/discovery.yaml
+++ b/jobs/delorean/ups-operator/ga/discovery.yaml
@@ -27,6 +27,10 @@
           default: 'ups-operator'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/ups/ga/discovery.yaml
+++ b/jobs/delorean/ups/ga/discovery.yaml
@@ -27,6 +27,10 @@
           default: 'ups'
           description: '[REQUIRED] Product to check, this affects the way the job verifies if a new version is available'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:

--- a/jobs/delorean/webapp/ga/discovery.yaml
+++ b/jobs/delorean/webapp/ga/discovery.yaml
@@ -42,6 +42,10 @@
           default: 'quay.io/integreatly/tutorial-web-app'
           description: '[OPTIONAL] Identifier to be used to retrieve the product version from the productVersionLocation'
           read-only: true
+      - bool:
+          name: 'updateLatestRHMIRelease'
+          default: false
+          description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
       scm:


### PR DESCRIPTION
Add updateLatestRHMIRelease param to all ga discovery jobs (Currently all default to false)
