### PR TITLE
Update openshift ci image stream template

### DIFF
--- a/openshift-ci/README.md
+++ b/openshift-ci/README.md
@@ -1,11 +1,28 @@
 
 # OpenShift CI
 
-The integeratly prow jobs are configured to use a [base image](https://github.com/openshift/release/blob/master/ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-master.yaml#L25) 
-containing all the tools required to build and execute the tests. In order to keep builds speedy, we use an image stream for the base image in the integr8ly namespace on [openshift ci](https://api.ci.openshift.org/console/project/integr8ly/browse/images/intly-base-image) 
+The integeratly prow jobs are configured to use a base image containing all the tools required to build and execute the tests. In order to keep builds speedy, we use an image stream for the base image in the integr8ly namespace on [openshift ci](https://api.ci.openshift.org/console/project/integr8ly/browse/images) 
 
-## Create Image Stream
+## Create Image Streams
 
 ```bash
-oc new-app -p GITHUB_ORG=integr8ly -p GITHUB_REF=master -f openshift-ci/templates/base-image-build-template.yml -n integr8ly
+oc new-app -p IMAGE_NAME=<image stream name> -p GITHUB_ORG=<github org name> -p GITHUB_REPO=<github repo name> -p GITHUB_REF=<git ref> -f openshift-ci/templates/base-image-build-template.yml -n integr8ly
+```
+
+Integreatly Operator
+
+```bash
+oc new-app -p IMAGE_NAME=intly-operator-base-image -p GITHUB_ORG=integr8ly -p GITHUB_REPO=integreatly-operator -p GITHUB_REF=master -f openshift-ci/templates/base-image-build-template.yml -n integr8ly
+```
+
+Heimdall Operator
+
+```bash
+oc new-app -p IMAGE_NAME=heimdall-base-image -p GITHUB_ORG=integr8ly -p GITHUB_REPO=heimdall -p GITHUB_REF=master -f openshift-ci/templates/base-image-build-template.yml -n integr8ly
+```
+
+Cloud Resource Operator
+
+```bash
+oc new-app -p IMAGE_NAME=cro-base-image -p GITHUB_ORG=integr8ly -p GITHUB_REPO=cloud-resource-operator -p GITHUB_REF=master -f openshift-ci/templates/base-image-build-template.yml -n integr8ly
 ```

--- a/openshift-ci/templates/base-image-build-template.yml
+++ b/openshift-ci/templates/base-image-build-template.yml
@@ -2,18 +2,14 @@
 apiVersion: v1
 kind: Template
 labels:
-  template: intly-base-image-build-template
+  template: intly-base-image-template
 metadata:
-  name: intly-base-image-build
+  name: intly-base-image
 objects:
 - apiVersion: v1
   kind: ImageStream
   metadata:
     name: ${IMAGE_NAME}
-    annotations:
-        slave-label: ${AGENT_LABEL}
-    labels:
-      role: jenkins-slave
 - apiVersion: v1
   kind: BuildConfig
   metadata:
@@ -26,7 +22,7 @@ objects:
     runPolicy: Serial
     source:
       git:
-        uri: https://github.com/${GITHUB_ORG}/ci-cd
+        uri: https://github.com/${GITHUB_ORG}/${GITHUB_REPO}
         ref: ${GITHUB_REF}
       contextDir: ${CONTEXT_DIR}
       type: Git
@@ -34,7 +30,7 @@ objects:
       dockerStrategy:
           noCache: true
           forcePull: true
-          dockerfilePath: Dockerfile.tools
+          dockerfilePath: ${DOCKERFILE_PATH}
       type: Docker
     triggers:
     - type: ImageChange
@@ -45,14 +41,20 @@ parameters:
   displayName: Github Organization
   name: GITHUB_ORG
   value: integr8ly
+- description: The name of the github repo to reference in the configuration
+  displayName: Github Repo
+  name: GITHUB_REPO
+  value: ci-cd
 - description: The name of the repository branch to reference in the configuration
   displayName: Branch
   name: GITHUB_REF
   value: master
-- description: The name of the OpenShift Service exposed for the Jenkins container.
-  displayName: Service Name
+- description: The name of the OpenShift Image Stream name
   name: IMAGE_NAME
   value: intly-base-image
-- description: The directory that houses the Dockerfile
+- description: The directory that contains the Dockerfile
   name: CONTEXT_DIR
   value: openshift-ci
+- description: The dockerfile path
+  name: DOCKERFILE_PATH
+  value: Dockerfile.tools


### PR DESCRIPTION
* Update openshift ci image stream template to make it generic enough to create all required image streams.
* Update README to include examples of image stream creation.
