### PR TITLE
updated OS4 master install pipeline and made build unstable if any of the tests fail

### DIFF
--- a/jobs/integr8ly/ocp4/install/image-deploy/Jenkinsfile
+++ b/jobs/integr8ly/ocp4/install/image-deploy/Jenkinsfile
@@ -102,6 +102,7 @@ node('cirhos_rhel7') {
                             sed -i "s@SELF_SIGNED_CERTS@${selfSignedCerts}@" deploy/crds/examples/integreatly-installation-cr.yaml
                             sed -i "s@INSTALLATION_NAME@${installationName}@" deploy/crds/examples/integreatly-installation-cr.yaml
                             sed -i "s@INSTALLATION_TYPE@${INSTALLATION_TYPE}@" deploy/crds/examples/integreatly-installation-cr.yaml
+                            sed -i "s@INSTALLATION_PREFIX@${INSTALLATION_PREFIX}@" deploy/crds/examples/integreatly-installation-cr.yaml
                         """
                     )
 

--- a/jobs/integr8ly/ocp4/install/image-deploy/openshift4-rhmi-image-install.yaml
+++ b/jobs/integr8ly/ocp4/install/image-deploy/openshift4-rhmi-image-install.yaml
@@ -44,6 +44,10 @@
             default: 'master'
             description: "Branch of the Integreatly Operator repository"
         - string:
+            name: INSTALLATION_PREFIX
+            default: 'rhmi'
+            description: "Value used to prefix the names of the namespaces created during RHMI installation (minus the hyphen)"
+        - string:
             name: RECIPIENTS
             default: ''
             description: "Whitespace- or comma-separated list of recipient addresses"

--- a/jobs/integr8ly/ocp4/nightly/executor/Jenkinsfile
+++ b/jobs/integr8ly/ocp4/nightly/executor/Jenkinsfile
@@ -122,6 +122,7 @@ def install(clusterName, clusterDomain, password) {
         string(name: 'CLUSTER_DOMAIN', value: clusterDomain),
         string(name: 'ADMIN_PASSWORD', value: password),
         string(name: 'INTEGREATLY_OPERATOR_BRANCH', value: "${INTEGREATLY_OPERATOR_BRANCH}"),
+        string(name: 'INSTALLATION_PREFIX', value: "${INSTALLATION_PREFIX}"),
         string(name: 'RECIPIENTS', value: "${RECIPIENTS}")
     ]
     if (OLM_INSTALLATION.toString() == 'true') {   
@@ -142,24 +143,29 @@ def addIDP(clusterName, clusterDomain, password) {
 }
 
 def test(clusterName, clusterDomain, password) {
-    build job: 'ocp4-all-tests-executor', parameters: [
+    parameters = [
         string(name: 'CLUSTER_NAME', value: clusterName),
         string(name: 'CLUSTER_DOMAIN', value: clusterDomain),
         string(name: 'ADMIN_PASSWORD', value: password)
     ]
+    if (OLM_INSTALLATION.toString() == 'false') {   
+        parameters.add(string(name: 'NAMESPACE_PREFIX', value: "${INSTALLATION_PREFIX}-"))
+    }
+
+    buildStatus = build(job: 'ocp4-all-tests-executor', parameters: parameters).result
+    if (buildStatus != 'SUCCESS') {
+        currentBuild.result = 'UNSTABLE'
+    }
 }
 
 def deprovisionCluster(clusterName) {
-    parameters = [
-        string(name: 'CLUSTER_NAME', value: clusterName),
-        string(name: 'RECIPIENTS', value: "${RECIPIENTS}")
-    ]
+    if (buildStatus == 'SUCCESS') {
+        parameters = [
+            string(name: 'CLUSTER_NAME', value: clusterName),
+            string(name: 'RECIPIENTS', value: "${RECIPIENTS}")
+        ]
 
-    buildStatus = build(job: 'openshift4-osd-cluster-deprovision', propagate: false, parameters: parameters).result
-    println "Build finished with ${buildStatus}"
-                    
-    if (buildStatus != 'SUCCESS') {
-        currentBuild.result = 'UNSTABLE'
+        build (job: 'openshift4-osd-cluster-deprovision', parameters: parameters)
     }
 }
 

--- a/jobs/integr8ly/ocp4/nightly/executor/osd-ocp4-testing-executor.yaml
+++ b/jobs/integr8ly/ocp4/nightly/executor/osd-ocp4-testing-executor.yaml
@@ -26,6 +26,10 @@
           name: OLM_INSTALLATION
           default: false
           description: "Indicates whether fixed release image (olm - when set to true) or master should be used for the installation"
+      - string:
+          name: INSTALLATION_PREFIX
+          default: 'rhmi'
+          description: "Value used to prefix the names of the namespaces created during RHMI installation (minus the hyphen)"
       - choice:
           name: TO_DO
           description: "It specifies what stages of the pipeline will be executed"

--- a/jobs/integr8ly/ocp4/nightly/trigger/master/osd-ocp4-master-testing-nightly-trigger.yaml
+++ b/jobs/integr8ly/ocp4/nightly/trigger/master/osd-ocp4-master-testing-nightly-trigger.yaml
@@ -18,6 +18,7 @@
             RECIPIENTS=integreatly-qe@redhat.com
             INTEGREATLY_OPERATOR_BRANCH=master
             TO_DO=provision + install + tests + destroy
+            INSTALLATION_PREFIX=rhmi
             OLM_INSTALLATION=false
     pipeline-scm:
       script-path: jobs/integr8ly/ocp4/nightly/trigger/Jenkinsfile

--- a/jobs/integr8ly/ocp4/tests/executor/Jenkinsfile
+++ b/jobs/integr8ly/ocp4/tests/executor/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 String clusterAPI = "https://api.${CLUSTER_NAME}.${CLUSTER_DOMAIN}"
-String webappUrl = "https://tutorial-web-app-integreatly-solution-explorer.apps.${CLUSTER_NAME}.${CLUSTER_DOMAIN}"
+String webappUrl = "https://tutorial-web-app-${NAMESPACE_PREFIX}solution-explorer.apps.${CLUSTER_NAME}.${CLUSTER_DOMAIN}"
 jobParams = [
     string(name: 'REPOSITORY', value: "${REPOSITORY}"),
     string(name: 'BRANCH', value: "${BRANCH}"),


### PR DESCRIPTION
## What
updated OS4 master install pipeline and made build unstable if any of the tests fail:

https://issues.redhat.com/browse/INTLY-4722
https://issues.redhat.com/browse/INTLY-4584

Installation executed here:

https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/ppaszki-image-deploy-install/1/console

tests against the cluster with the installation from above executed here: https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/OS4/job/ocp4-all-tests-executor/98/console
