### PR TITLE
update fuse check to new repo

### DIFF
--- a/jobs/delorean/fuse-online/ga/discovery.yaml
+++ b/jobs/delorean/fuse-online/ga/discovery.yaml
@@ -15,12 +15,12 @@
           read-only: true
       - string:
           name: 'projectOrg'
-          default: 'syndesisio'
+          default: 'jboss-fuse'
           description: '[REQUIRED] github project organization'
           read-only: true
       - string:
           name: 'projectRepo'
-          default: 'fuse-online-install'
+          default: 'fuse-clients'
           description: '[REQUIRED] github project repository'
           read-only: true
       - string:

--- a/jobs/delorean/fuse-online/rc/discovery.yaml
+++ b/jobs/delorean/fuse-online/rc/discovery.yaml
@@ -4,7 +4,7 @@
     display-name: 'fuse-online-rc-discovery'
     project-type: pipeline
     concurrent: false
-    disabled: false
+    disabled: true
     triggers:
       - timed: '@daily'
     parameters:

--- a/jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/discovery/ga/github/Jenkinsfile
@@ -61,11 +61,7 @@ String[] extractSemVer(String productVersion, String productName) {
 }
 
 boolean verifyIsGA(String product, String version) {
-    if (product == "fuse-online") {
-        //ToDo Since fuse online have changed their installation we have currently have no way of knowing if it's GA or not.
-        return version < "1.9.0"
-    }
-    return true
+      return true
 }
 
 String findLatestVersionFor(String product, String currentVersion, List allVersions, String type, List levels) {


### PR DESCRIPTION
## JIRA
https://issues.redhat.com/browse/INTLY-4779

## What
Update the fuse ga discovery check to jboss-fuse/fuse-clients
Remove is GA check which limited the fuse check to pre 1.9 versions
Disable fuse rc discovery check.

## Verification
See this[ build output](https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Delorean/job/delorean-fuse-online/job/ga/job/discovery-test/10/console) 
current product release `[INFO] currentProductRelease = 1.8.18` which is correct [here](https://github.com/integr8ly/installation/blob/master/inventories/group_vars/all/manifest.yaml#L38)
latest product release   `[INFO] Latest Product Version 1.8.18` which is correct [here](https://github.com/jboss-fuse/fuse-clients/releases)

There was no pr created as this was manually [changed](https://github.com/integr8ly/installation/commit/7c5248814c18a5437369d165200695ac7182d2ce#diff-15e7e03f5a684bad56e00d52ba85f461R38) - confirmed by ```+ git push origin fuse-online-ga --force
Everything up-to-date```

I'd expect that when there's a new version tagged on the repo that we'd see a pr. 