### PR TITLE
add docs for local jenkins job dev and test in jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,79 +1,10 @@
-# ci-cd
-Continuous Integration / Continuous Delivery related bits
-
-## Table of contents
-- [1. Jenkins Job Builder](#1-jenkins-job-builder)
-  - [1.1 Installation](#11-installation)
-    - [1.1.1 Linux](#111-linux)
-    - [1.1.2 Mac](#112-mac)
-  - [1.2 Configuration of JJB](#12-configuration-of-jjb)
-  - [1.3 Test your template](#13-test-your-template)
-  - [1.4 Update your job](#14-update-your-job)
-  - [1.5 Generate inline script jobs](#15-generate-inline-script-jobs)
-  - [1.6 Configure all jobs and views](#16-configure-all-jobs-and-views)
-  - [1.7 Troubleshooting](#17-troubleshooting)
-- [2. Delorean](#2-delorean)
-  - [2.1 Contributing](#21-contributing)
+# Integreatly Continuous Integration / Continuous Delivery
+This repo contains Continuous Integration / Continuous Delivery related items for the integreatly project.
 
 ## 1. Jenkins Job Builder
-Job definitions are stored in form of templates for [Jenkins Job Builder](https://docs.openstack.org/infra/jenkins-job-builder/) (JJB). 
 
-### 1.1 Installation
-
-#### 1.1.1 Linux
-Go to https://docs.openstack.org/infra/jenkins-job-builder/ and follow the instructions.
-
-#### 1.1.2 Mac
-Install jjb using Brew:
-
-`brew install jenkins-job-builder`
-
-### 1.2 Configuration of JJB
-Create `jenkins_job.ini` file containing
-```
-[job_builder]
-ignore_cache=True
-keep_descriptions=False
-include_path=.:../scripts:~/git/
-recursive=False
-allow_duplicates=False
-
-[jenkins]
-user=<YOUR_USERNAME>
-password=<YOUR_PASSWORD>
-url=<YOUR_JENKINS_INSTANCE_URL>
-query_plugins_info=False
-```
-
-### 1.3 Test your template
-```
-jenkins-jobs --conf /path/to/your/jenkins_jobs.ini test /path/to/your/template.yaml
-```
-
-### 1.4 Update your job
-```
-jenkins-jobs --conf /path/to/your/jenkins_jobs.ini update /path/to/your/template.yaml
-```
-
-### 1.5 Generate inline script jobs
-```
-./scripts/generate_inline_script_pipeline_job -j /path/to/your/template.yaml -o /path/to/your/generated/jobs
-```
-
-### 1.6 Configure all jobs and views
-```
-./scripts/configure_jenkins /path/to/your/jenkins_jobs.ini
-```
-
-### 1.7 Troubleshooting
-To prevent from getting SSL: CERTIFICATE_VERIFY_FAILED when running jenkins-jobs commands:
-`ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain`
-
-execute the following command in the terminal:
-
-```
-export PYTHONHTTPSVERIFY=0
-```
+Documentation related to Jenkins Job Builder are located [here](jobs/README.md)
+Documentation related to local development against integreatly-qe-jenkins are located [here](jobs/local-development.md)
 
 ## 2. Delorean
 

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -1,0 +1,73 @@
+## Table of contents
+- [1. Jenkins Job Builder](#1-jenkins-job-builder)
+  - [1.1 Installation](#11-installation)
+    - [1.1.1 Linux](#111-linux)
+    - [1.1.2 Mac](#112-mac)
+  - [1.2 Configuration of JJB](#12-configuration-of-jjb)
+  - [1.3 Test your template](#13-test-your-template)
+  - [1.4 Update your job](#14-update-your-job)
+  - [1.5 Generate inline script jobs](#15-generate-inline-script-jobs)
+  - [1.6 Configure all jobs and views](#16-configure-all-jobs-and-views)
+  - [1.7 Troubleshooting](#17-troubleshooting)
+- [2. Delorean](#2-delorean)
+  - [2.1 Contributing](#21-contributing)
+
+## 1. Jenkins Job Builder
+Job definitions are stored in form of templates for [Jenkins Job Builder](https://docs.openstack.org/infra/jenkins-job-builder/) (JJB). 
+
+### 1.1 Installation
+
+#### 1.1.1 Linux
+Go to https://docs.openstack.org/infra/jenkins-job-builder/ and follow the instructions.
+
+#### 1.1.2 Mac
+Install jjb using Brew:
+
+`brew install jenkins-job-builder`
+
+### 1.2 Configuration of JJB
+Create `jenkins_job.ini` file containing
+```
+[job_builder]
+ignore_cache=True
+keep_descriptions=False
+include_path=.:../scripts:~/git/
+recursive=False
+allow_duplicates=False
+
+[jenkins]
+user=<YOUR_USERNAME>
+password=<YOUR_PASSWORD>
+url=<YOUR_JENKINS_INSTANCE_URL>
+query_plugins_info=False
+```
+
+### 1.3 Test your template
+```
+jenkins-jobs --conf /path/to/your/jenkins_jobs.ini test /path/to/your/template.yaml
+```
+
+### 1.4 Update your job
+```
+jenkins-jobs --conf /path/to/your/jenkins_jobs.ini update /path/to/your/template.yaml
+```
+
+### 1.5 Generate inline script jobs
+```
+./scripts/generate_inline_script_pipeline_job -j /path/to/your/template.yaml -o /path/to/your/generated/jobs
+```
+
+### 1.6 Configure all jobs and views
+```
+./scripts/configure_jenkins /path/to/your/jenkins_jobs.ini
+```
+
+### 1.7 Troubleshooting
+To prevent from getting SSL: CERTIFICATE_VERIFY_FAILED when running jenkins-jobs commands:
+`ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate in certificate chain`
+
+execute the following command in the terminal:
+
+```
+export PYTHONHTTPSVERIFY=0
+```

--- a/jobs/local-development.md
+++ b/jobs/local-development.md
@@ -1,0 +1,60 @@
+# Local Development Setup for testing Jenkins Jobs in integreatly-qe-jenkins
+
+The steps below will get you (fairly) quickly set up for local development on the jenkins jobs located in this folder. This  allows you to test the changes on integreatly-qe-jenkins. Things get reset to master daily but remember: with great power comes great responsibility.
+
+
+## Pre-req
+
+- Admin access on [integreatly-qe-jenkins](https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/) - contact the delorean team channel on gchat
+- [pyyaml](https://pypi.org/project/PyYAML/) 
+
+## Create jenkins config file
+
+In the root of your local ci-cd repo paste the following into a new file `jenkins-config.ini` replacing username and password with your credentials from [here](https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/me/) -> Configure -> Show Api Token using  `User ID` for <username> and `API Token` for <password>
+ 
+```
+[job_builder]
+ignore_cache=True
+keep_descriptions=False
+include_path=.:scripts:~/git/
+recursive=False
+exclude=.*:manual:./development
+allow_duplicates=False
+
+[jenkins]
+url = https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com
+user = <username>
+password = <password>
+query_plugins_info=False
+```
+
+## Make a copy of the job you want to test
+
+Example steps:
+
+Copy 
+`jobs/delorean/fuse-online/ga/discovery.yaml`
+to 
+`jobs/delorean/fuse-online/ga/discovery-test.yaml`
+
+Append `-test` to job `name` and job `display-name` in the new test file.
+
+Make the required changes to this file or the related Jenkinsfile (search for `script-path` in the yaml file)
+In the example case that is:
+`jobs/delorean/jenkinsfiles/discovery/ga/Jenkinsfile`
+
+## Sync the new job to Jenkins
+
+### Update script
+
+In scripts/configure_jenkins_test.sh Uncomment the line to include the path to your `-test.yaml` file
+
+### Sync the changes
+To sync this new job or new changes to the job run:
+
+```
+./scripts/configure_jenkins_test.sh ./scripts/jenkins-config.ini
+```
+ 
+You should see a new job or existing job updated with the name provided in the yaml file.
+

--- a/scripts/configure_jenkins_test.sh
+++ b/scripts/configure_jenkins_test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Exit on error
+set -e
+# Verbose output of cmds
+# set -x
+
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CONFIG="$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
+
+alias jenkins-jobs="docker run --env PYTHONHTTPSVERIFY=0 --privileged --rm -v $SCRIPTS_DIR/..:$SCRIPTS_DIR/.. docker-registry.engineering.redhat.com/mobile/jenkins-job-builder:latest jenkins-jobs"
+
+generate_inline_script_job() {
+  $SCRIPTS_DIR/generate_inline_script_pipeline_job -j $1 -o $SCRIPTS_DIR/../jobs/generated
+}
+
+rm -rf $SCRIPTS_DIR/../jobs/generated/*
+
+# Uncomment the below lines for the Job you want to test
+# generate_inline_script_job $SCRIPTS_DIR/../path/to/job-test.yaml
+
+jenkins-jobs --conf $CONFIG update $SCRIPTS_DIR/../jobs/generated/


### PR DESCRIPTION
## What
- Add steps to get set up for local dev and test of jenkins jobs
- Adding new script to save on having to comment out lines in the main sync script.
- Reduce the content in the root README
- Move JJB setup to it's own README under jobs folder
