### PR TITLE
fix: msb test - wait for pod to be ready

### DIFF
--- a/jobs/integr8ly/ocp3/test-suites/msb-integration-test.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/msb-integration-test.yaml
@@ -102,6 +102,7 @@
                     # make sure msb pod is running before executing the tests
                     until oc get pods | grep 1/1; do sleep 2; done
                     oc expose svc/msb
+                    sleep 1m
                   """
                   
                   // I wasn't able to do this in one single sh command. There are two issues, which I don't know how to solve

--- a/jobs/integr8ly/ocp3/test-suites/msb-integration-test.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/msb-integration-test.yaml
@@ -99,6 +99,8 @@
                     oc patch deployment msb -n openshift-managed-service-broker -p  '{ "spec": { "template": { "spec": { "containers": [{ "name": "managed-service-broker", "image": "quay.io/integreatly/managed-service-broker:master" }]}}}}'
                     sleep 10
                     oc project openshift-managed-service-broker
+                    # make sure msb pod is running before executing the tests
+                    until oc get pods | grep 1/1; do sleep 2; done
                     oc expose svc/msb
                   """
                   


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

MSB test pipeline sometimes fails [1] with:

```
--- FAIL: TestManagedBroker (0.21s)
01:39:00     managedServicesBroker_test.go:80: Error getting Catalog: 503 Service Unavailable
```

This is probably caused by pod not being ready yet. This change makes sure, that pod is ready before running the test.

[1] https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/msb-integration-test/319/console