### PR TITLE
[WIP] add stage to ocp4 cluster create for configuring vpc peering connections

### DIFF
--- a/jobs/openshift4/cluster/create/Jenkinsfile
+++ b/jobs/openshift4/cluster/create/Jenkinsfile
@@ -91,6 +91,60 @@ node("cirhos_rhel7") {
                     }
                 }
             }
+
+            stage("Configure VPC Peering Connection") {
+              def cloudResourceVPCId = "default"
+              def metadataFile = "${installConfigDirectory}metadata.json"
+              def clusterMetadata = readJSON file: metadataFile
+              def clusterId = clusterMetadata['infraID']
+
+              // Get cluster VPC
+              String clusterVPCId = sh (
+                script: "aws ec2 describe-vpcs --filters Name=tag:Name,Values=${clusterId} | jq '.[] | .[] | .VpcId'",
+                returnStdout: true
+              ).trim()
+
+              // Get cloud-resources VPC
+              String cloudResourceVPCId = sh (
+                script: "aws ec2 describe-vpcs --filters Name=tag:Name,Values=${cloudResourceVPCId} | jq '.[] | .[] | .VpcId'",
+                returnStdout: true
+              ).trim()
+
+              // Create vpc peering connection
+              String vpcPeeringConnectionId = sh (
+                script: "aws ec2 create-vpc-peering-connection --vpc-id ${clusterVPCId} --peer-vpc-id ${cloudResourceVPCId} | jq '.VpcPeeringConnection | .VpcPeeringConnectionId'",
+                returnStdout: true
+              ).trim()
+
+              // Accept newly created peering connection
+              sh "aws ec2 accept-vpc-peering-connection --vpc-peering-connection-id ${vpcPeeringConnectionId}"
+
+              // Add peering connection route to cluster VPC
+              String clusterRouteTableId = sh (
+                script: "aws ec2 describe-route-tables --filters Name=tag:Name,Values=${clusterId}-public | jq '.[] | .[] | .RouteTableId'",
+                returnStdout: true
+              ).trim()
+
+              String cloudResourceCIDR = sh (
+                script: "aws ec2 describe-vpcs --vpc-id ${cloudResourceVPCId} | jq '.[] | .[] | .CidrBlockAssociationSet | .[] | .CidrBlock'",
+                returnStdout: true
+              ).trim()
+
+              sh "aws ec2 create-route --route-table-id ${clusterRouteTableId} --destination-cidr-block ${cloudResourceCIDR}--vpc-peering-connection-id ${vpcPeeringConnectionId}"
+
+              // Add peering connection route to cloud-resources VPC
+              String cloudResourceRouteTableId = sh (
+                script: "aws ec2 describe-route-tables --filters Name=vpc-id,Values=${cloudResourceVPCId} | jq '.[] | .[] | .RouteTableId'",
+                returnStdout: true
+              ).trim()
+
+              String clusterResourceCIDR = sh (
+                script: "aws ec2 describe-vpcs --vpc-id ${clusterVPCId} | jq '.[] | .[] | .CidrBlockAssociationSet | .[] | .CidrBlock'",
+                returnStdout: true
+              ).trim()
+
+              sh "aws ec2 create-route --route-table-id ${cloudResourceRouteTableId} --destination-cidr-block ${clusterResourceCIDR}--vpc-peering-connection-id ${vpcPeeringConnectionId}"
+            }
             
             stage("Install dedicated-admin operator") {
                 String installationLog = sh (


### PR DESCRIPTION
## What
Add a stage to the OCP4 cluster create pipeline for configuring VPC peering connections needed for running the e2e tests of the integreatly operator that is configured to use AWS resources.

In order for this to work, the AWS account to be used for this need to have the right permissions. More details in the JIRA: https://issues.redhat.com/browse/INTLY-4256

The steps below are based on the following guide: https://github.com/integr8ly/cloud-resource-operator#vpc-peering

