### PR TITLE
Update intly operator branch to 1.15.0 for OLM

### DIFF
--- a/jobs/integr8ly/ocp4/nightly/trigger/olm/osd-ocp4-olm-testing-nightly-trigger.yaml
+++ b/jobs/integr8ly/ocp4/nightly/trigger/olm/osd-ocp4-olm-testing-nightly-trigger.yaml
@@ -16,7 +16,7 @@
           properties-content: |
             CLUSTER_NAME=nightly-olm
             RECIPIENTS=integreatly-qe@redhat.com
-            INTEGREATLY_OPERATOR_BRANCH=1.14.0
+            INTEGREATLY_OPERATOR_BRANCH=1.15.0
             TO_DO=provision + install + tests + destroy
             OLM_INSTALLATION=true
     pipeline-scm:


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

Nightly started to fail deploying intly operator, the reason is that there is a new version of the operator. 