### PR TITLE
change cluster name for delorean nightly

### DIFF
--- a/jobs/integr8ly/ocp3/delorean-testing-nightly-trigger.yaml
+++ b/jobs/integr8ly/ocp3/delorean-testing-nightly-trigger.yaml
@@ -24,7 +24,7 @@
                     buildStatus = build(job: 'openshift-cluster-integreatly-test', propagate: false, parameters: [
                         string(name: 'installationGitUrl', value: "${installationGitUrl}"),
                         string(name: 'installationGitBranch', value: "${installationGitBranch}"),
-                        string(name: 'clusterName', value: "qe-master-new"),
+                        string(name: 'clusterName', value: "qe-master-nightly"),
                         booleanParam(name: 'dryRun', value: Boolean.valueOf("${dryRun}"))
                     ]).result
 


### PR DESCRIPTION
## What
<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->

There was an issue recently with clashing names of AWS resources being created by Tower when creating cluster. Probably caused by using both Eng and QE Towers recently. This change is just a workaround for now, so that nightly pipeline can run.