### PR TITLE
EWS discovery job updates

### DIFF
--- a/jobs/delorean/1.0/ews/3scale/ga/discovery.yaml
+++ b/jobs/delorean/1.0/ews/3scale/ga/discovery.yaml
@@ -30,7 +30,7 @@
           read-only: true
       - bool:
           name: 'updateLatestRHMIRelease'
-          default: false
+          default: true
           description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/1.0/ews/discovery/ga/github/Jenkinsfile

--- a/jobs/delorean/1.0/ews/amq-online/ga/discovery.yaml
+++ b/jobs/delorean/1.0/ews/amq-online/ga/discovery.yaml
@@ -35,7 +35,7 @@
           read-only: true
       - bool:
           name: 'updateLatestRHMIRelease'
-          default: false
+          default: true
           description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/1.0/ews/discovery/ga/github/Jenkinsfile

--- a/jobs/delorean/1.0/ews/codeready/ga/discovery.yaml
+++ b/jobs/delorean/1.0/ews/codeready/ga/discovery.yaml
@@ -40,7 +40,7 @@
           read-only: true
       - bool:
           name: 'updateLatestRHMIRelease'
-          default: false
+          default: true
           description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/1.0/ews/discovery/ga/github/Jenkinsfile

--- a/jobs/delorean/1.0/ews/fuse-online/ga/discovery.yaml
+++ b/jobs/delorean/1.0/ews/fuse-online/ga/discovery.yaml
@@ -45,7 +45,7 @@
           read-only: true
       - bool:
           name: 'updateLatestRHMIRelease'
-          default: false
+          default: true
           description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/1.0/ews/discovery/ga/github/Jenkinsfile

--- a/jobs/delorean/1.0/ews/rhsso/ga/branch.yaml
+++ b/jobs/delorean/1.0/ews/rhsso/ga/branch.yaml
@@ -4,7 +4,7 @@
     display-name: 'rhsso-ga-branch'
     project-type: pipeline
     concurrent: false
-    disabled: true
+    disabled: false
     parameters:
       - string:
           name: 'installationGitUrl'

--- a/jobs/delorean/1.0/ews/rhsso/ga/discovery.yaml
+++ b/jobs/delorean/1.0/ews/rhsso/ga/discovery.yaml
@@ -4,7 +4,7 @@
     display-name: 'rhsso-ga-discovery'
     project-type: pipeline
     concurrent: false
-    disabled: true
+    disabled: false
     triggers:
       - timed: '@hourly'
     parameters:
@@ -45,7 +45,7 @@
           read-only: true
       - bool:
           name: 'updateLatestRHMIRelease'
-          default: false
+          default: true
           description: '[OPTIONAL] Update the latest RHMI release branch with patch releases!'
     pipeline-scm:
       script-path: jobs/delorean/jenkinsfiles/1.0/ews/discovery/ga/github/Jenkinsfile

--- a/jobs/delorean/jenkinsfiles/1.0/ews/discovery/ga/github/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/1.0/ews/discovery/ga/github/Jenkinsfile
@@ -326,12 +326,16 @@ node() {
         println "[INFO] Latest Product Release = ${latestReleases}"
     }
 
+    //Only apply product patch updates to master if we have opted to not update the latest release for this product
+    List masterVersionLevels = updateLatestRHMIRelease ? ['major', 'minor'] : ['major', 'minor', 'patch']
+    List latestReleaseVersionLevels = ['patch']
+
     processInstallationBranch {
         branch = gaBranch
         baseBranch = installationGitRef
         product = productName
         latestProductReleases = latestReleases
-        updateVersionLevels = ['major', 'minor', 'patch']
+        updateVersionLevels = masterVersionLevels
         updateVersionType = 'ga'
     }
 
@@ -352,7 +356,7 @@ node() {
             baseBranch = latestRHMIBranch
             product = productName
             latestProductReleases = latestReleases
-            updateVersionLevels = ['patch']
+            updateVersionLevels = latestReleaseVersionLevels
             updateVersionType = 'ga'
         }
     }


### PR DESCRIPTION
## What

* Only apply product patch updates to master if we have opted to not update the latest release for this product.
* Re-enabled rhsso ews jobs
* Set updateLatestRHMIRelease to true for rhsso, 3scale, amq-online and fuse-online. All others will just PR any updates, including patch updates, back to master.


