### PR TITLE
Intly 5000

### DIFF
--- a/jobs/integr8ly/ocp3/test-suites/amq-online-address-creation-test.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/amq-online-address-creation-test.yaml
@@ -39,6 +39,10 @@
       - string:
           name: NAMESPACE_PREFIX
           description: "Value used to prefix the names of the namespaces created during Integr8ly installation"
+      - bool:
+          name: FINAL_CHECK_ONLY
+          default: false
+          description: 'defaults to false. When set to true - this entire test is skipped and only final part of fuse wt1 test is executed'
     dsl: |
         timeout(10) { ansiColor('gnome-terminal') { timestamps {
             node('cirhos_rhel7'){

--- a/jobs/integr8ly/ocp3/test-suites/fuse-test.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/fuse-test.yaml
@@ -38,7 +38,15 @@
       - string:
           name: TIMEOUT_THRESHOLD
           default: '1'
-          description: 'optionally increase timeout values. If you provide value 2 it means it will be sleeping/waiting two times longer'      
+          description: 'optionally increase timeout values. If you provide value 2 it means it will be sleeping/waiting two times longer'
+      - bool:
+          name: W1_FINAL_VERIFICATION
+          default: false
+          description: 'Expects existing AMQ Online address. When it's set to true then it verifies last step (sending data (order) from one REST app to another) in W1. This defaults to false.'
+      - bool:
+          name: FINAL_CHECK_ONLY
+          default: false
+          description: 'defaults to false. When set to true - only the final check is performed (e.g. whether it is possible to send an order and see it appearing in the list of orders)'
     dsl: |
         timeout(10) { ansiColor('gnome-terminal') { timestamps {
             node('cirhos_rhel7'){

--- a/jobs/integr8ly/ocp3/test-suites/w1-test-executor.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/w1-test-executor.yaml
@@ -38,7 +38,15 @@
       - string:
           name: TIMEOUT_THRESHOLD
           default: '1'
-          description: 'optionally increase timeout values. If you provide value 2 it means it will be sleeping/waiting two times longer'      
+          description: 'optionally increase timeout values. If you provide value 2 it means it will be sleeping/waiting two times longer'
+      - bool:
+          name: W1_FINAL_VERIFICATION
+          default: true
+          description: 'Expects existing AMQ Online address. When it's set to true then it verifies last step of fuse test (sending data (order) from one REST app to another) in W1. This defaults to false.'
+      - bool:
+          name: FINAL_CHECK_ONLY
+          default: false
+          description: 'defaults to false. When set to true - this entire test is skipped and only final part of fuse wt1 test is executed'
     dsl: |
         def err = null
         try {
@@ -62,7 +70,8 @@
                                     string(name: 'ADMIN_PASSWORD', value: "${ADMIN_PASSWORD}"),
                                     string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
                                     string(name: 'TIMEOUT_THRESHOLD', value: "${TIMEOUT_THRESHOLD}"),
-                                    booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("false"))
+                                    booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("false")),
+                                    booleanParam(name: 'FINAL_CHECK_ONLY', value: Boolean.valueOf("${FINAL_CHECK_ONLY}"))
                                 ]).result;
 
                                 println "Build finished with ${buildStatus}"
@@ -82,7 +91,8 @@
                                     string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
                                     string(name: 'TIMEOUT_THRESHOLD', value: "${TIMEOUT_THRESHOLD}"),
                                     booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("${CLEAN_RESOURCES}")),
-                                    booleanParam(name: 'W1_FINAL_VERIFICATION', value: Boolean.valueOf("true"))
+                                    booleanParam(name: 'W1_FINAL_VERIFICATION', value: Boolean.valueOf("${W1_FINAL_VERIFICATION}")),
+                                    booleanParam(name: 'FINAL_CHECK_ONLY', value: Boolean.valueOf("${FINAL_CHECK_ONLY}"))
                                 ]).result;
 
                                 println "Build finished with ${buildStatus}"


### PR DESCRIPTION
## What
https://issues.redhat.com/browse/INTLY-5000 - enabled running only final check on wt1 backend tests

Executed here: https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/ppaszki-wt1/7/console (no cleanup of resources) and here https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/ppaszki-wt1/8/console (with the resources cleanup)
