### PR TITLE
added final check only param to w2 testing executor

### DIFF
--- a/jobs/integr8ly/ocp3/test-suites/3scale-test.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/3scale-test.yaml
@@ -38,7 +38,11 @@
       - string:
           name: TIMEOUT_THRESHOLD
           default: '1'
-          description: 'optionally increase timeout values. If you provide value 2 it means it will be sleeping/waiting two times longer'      
+          description: 'optionally increase timeout values. If you provide value 2 it means it will be sleeping/waiting two times longer'
+      - bool:
+          name: FINAL_CHECK_ONLY
+          default: false
+          description: 'defaults to false. When set to true - only final checks of the individual wt2 related tests are checked'
     dsl: |
         timeout(35) { ansiColor('gnome-terminal') { timestamps {
             node('cirhos_rhel7'){

--- a/jobs/integr8ly/ocp3/test-suites/launcher-test.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/launcher-test.yaml
@@ -44,7 +44,11 @@
       - string:
           name: TIMEOUT_THRESHOLD
           default: '1'
-          description: 'optionally increase timeout values. If you provide value 2 it means it will be sleeping/waiting two times longer'      
+          description: 'optionally increase timeout values. If you provide value 2 it means it will be sleeping/waiting two times longer'
+      - bool:
+          name: FINAL_CHECK_ONLY
+          default: false
+          description: 'defaults to false. When set to true - only final checks of the individual wt2 related tests are checked'
     dsl: |
         timeout(35) { ansiColor('gnome-terminal') { timestamps {
             node('cirhos_rhel7'){

--- a/jobs/integr8ly/ocp3/test-suites/w2-test-executor.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/w2-test-executor.yaml
@@ -44,11 +44,15 @@
       - string:
           name: TIMEOUT_THRESHOLD
           default: '1'
-          description: 'optionally increase timeout values. If you provide value 2 it means it will be sleeping/waiting two times longer'      
+          description: 'optionally increase timeout values. If you provide value 2 it means it will be sleeping/waiting two times longer'
+      - bool:
+          name: FINAL_CHECK_ONLY
+          default: false
+          description: 'defaults to false. When set to true - only final checks of the individual wt2 related tests are checked'
     dsl: |
         def err = null
         try {
-            timeout(40) { 
+            timeout(90) { 
                 ansiColor('gnome-terminal') { 
                     timestamps {
                         node('cirhos_rhel7') {        
@@ -70,7 +74,8 @@
                                     string(name: 'TIMEOUT_THRESHOLD', value: "${TIMEOUT_THRESHOLD}"),
                                     string(name: 'GH_USER', value: "${GH_USER}"),
                                     string(name: 'GH_PERSONAL_TOKEN', value: "${GH_PERSONAL_TOKEN}"),
-                                    booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("${CLEAN_RESOURCES}"))
+                                    booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("${CLEAN_RESOURCES}")),
+                                    booleanParam(name: 'FINAL_CHECK_ONLY', value: Boolean.valueOf("${FINAL_CHECK_ONLY}"))
                                 ]).result;
 
                                 println "Build finished with ${buildStatus}"
@@ -110,7 +115,8 @@
                                     string(name: 'ADMIN_PASSWORD', value: "${ADMIN_PASSWORD}"),
                                     string(name: 'EVALS_USERNAME', value: "${EVALS_USERNAME}"),
                                     string(name: 'TIMEOUT_THRESHOLD', value: "${TIMEOUT_THRESHOLD}"),
-                                    booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("${CLEAN_RESOURCES}"))
+                                    booleanParam(name: 'CLEAN_RESOURCES', value: Boolean.valueOf("${CLEAN_RESOURCES}")),
+                                    booleanParam(name: 'FINAL_CHECK_ONLY', value: Boolean.valueOf("${FINAL_CHECK_ONLY}"))
                                 ]).result;
 
                                 println "Build finished with ${buildStatus}"


### PR DESCRIPTION
## What
added final check only param to w2 testing executor - https://issues.redhat.com/browse/INTLY-5001

This PR corresponds to changes here: 

Executed here: https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/all/job/ppaszki-wt2/6/console
