### PR TITLE
fix: updates location of jenkins-job-builder image

### DIFF
--- a/scripts/configure_delorean.sh
+++ b/scripts/configure_delorean.sh
@@ -8,7 +8,7 @@ set -e
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CONFIG="$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
 
-alias jenkins-jobs="docker run --env PYTHONHTTPSVERIFY=0 --privileged --rm -v $SCRIPTS_DIR/..:$SCRIPTS_DIR/.. docker-registry.engineering.redhat.com/mobile/jenkins-job-builder:latest jenkins-jobs"
+alias jenkins-jobs="docker run --env PYTHONHTTPSVERIFY=0 --privileged --rm -v $SCRIPTS_DIR/..:$SCRIPTS_DIR/.. docker-registry.upshift.redhat.com/jenkins-csb-intly-jjb/jenkins-job-builder:latest jenkins-jobs"
 
 generate_inline_script_job() {
   $SCRIPTS_DIR/generate_inline_script_pipeline_job -j $1 -o $SCRIPTS_DIR/../jobs/generated

--- a/scripts/configure_jenkins.sh
+++ b/scripts/configure_jenkins.sh
@@ -8,7 +8,7 @@ set -e
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CONFIG="$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
 
-alias jenkins-jobs="docker run --env PYTHONHTTPSVERIFY=0 --privileged --rm -v $SCRIPTS_DIR/..:$SCRIPTS_DIR/.. docker-registry.engineering.redhat.com/mobile/jenkins-job-builder:latest jenkins-jobs"
+alias jenkins-jobs="docker run --env PYTHONHTTPSVERIFY=0 --privileged --rm -v $SCRIPTS_DIR/..:$SCRIPTS_DIR/.. docker-registry.upshift.redhat.com/jenkins-csb-intly-jjb/jenkins-job-builder:latest jenkins-jobs"
 
 generate_inline_script_job() {
   $SCRIPTS_DIR/generate_inline_script_pipeline_job -j $1 -o $SCRIPTS_DIR/../jobs/generated

--- a/scripts/configure_jenkins_test.sh
+++ b/scripts/configure_jenkins_test.sh
@@ -8,7 +8,7 @@ set -e
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CONFIG="$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
 
-alias jenkins-jobs="docker run --env PYTHONHTTPSVERIFY=0 --privileged --rm -v $SCRIPTS_DIR/..:$SCRIPTS_DIR/.. docker-registry.engineering.redhat.com/mobile/jenkins-job-builder:latest jenkins-jobs"
+alias jenkins-jobs="docker run --env PYTHONHTTPSVERIFY=0 --privileged --rm -v $SCRIPTS_DIR/..:$SCRIPTS_DIR/.. docker-registry.upshift.redhat.com/jenkins-csb-intly-jjb/jenkins-job-builder:latest jenkins-jobs"
 
 generate_inline_script_job() {
   $SCRIPTS_DIR/generate_inline_script_pipeline_job -j $1 -o $SCRIPTS_DIR/../jobs/generated


### PR DESCRIPTION
## What
https://issues.redhat.com/browse/INTLY-5181

`jenkins-job-builder` image no longer available at `docker-registry.engineering.redhat.com`. Pushed image to PSI openshift registry and updated registry reference to point at that new location.
