### PR TITLE
fix: remove single quote within description

### DIFF
--- a/jobs/integr8ly/ocp3/test-suites/fuse-test.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/fuse-test.yaml
@@ -42,7 +42,7 @@
       - bool:
           name: W1_FINAL_VERIFICATION
           default: false
-          description: 'Expects existing AMQ Online address. When it's set to true then it verifies last step (sending data (order) from one REST app to another) in W1. This defaults to false.'
+          description: 'Expects existing AMQ Online address. When it is set to true then it verifies last step (sending data (order) from one REST app to another) in W1. This defaults to false.'
       - bool:
           name: FINAL_CHECK_ONLY
           default: false

--- a/jobs/integr8ly/ocp3/test-suites/w1-test-executor.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/w1-test-executor.yaml
@@ -42,7 +42,7 @@
       - bool:
           name: W1_FINAL_VERIFICATION
           default: true
-          description: 'Expects existing AMQ Online address. When it's set to true then it verifies last step of fuse test (sending data (order) from one REST app to another) in W1. This defaults to false.'
+          description: 'Expects existing AMQ Online address. When it is set to true then it verifies last step of fuse test (sending data (order) from one REST app to another) in W1. This defaults to false.'
       - bool:
           name: FINAL_CHECK_ONLY
           default: false


### PR DESCRIPTION
## What
Fix this issue:
```
INFO:jenkins_jobs.cli.subcommand.update:Updating jobs in ['/home/jenkins/workspace/recreate-pipelines/scripts/../jobs/integr8ly/ocp3/test-suites/fuse-test.yaml'] ([])
Traceback (most recent call last):
  File "/usr/local/bin/jenkins-jobs", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/jenkins_jobs/cli/entry.py", line 146, in main
    jjb.execute()
  File "/usr/local/lib/python2.7/site-packages/jenkins_jobs/cli/entry.py", line 140, in execute
    ext.obj.execute(self.options, self.jjb_config)
  File "/usr/local/lib/python2.7/site-packages/jenkins_jobs/cli/subcommand/update.py", line 135, in execute
    options, jjb_config)
  File "/usr/local/lib/python2.7/site-packages/jenkins_jobs/cli/subcommand/update.py", line 108, in _generate_xmljobs
    parser.load_files(options.path)
  File "/usr/local/lib/python2.7/site-packages/jenkins_jobs/parser.py", line 133, in load_files
    self.parse(in_file)
  File "/usr/local/lib/python2.7/site-packages/jenkins_jobs/parser.py", line 168, in parse
    self._parse_fp(fp)
  File "/usr/local/lib/python2.7/site-packages/jenkins_jobs/parser.py", line 137, in _parse_fp
    data = local_yaml.load(utils.wrap_stream(fp), search_path=self.path)
  File "/usr/local/lib/python2.7/site-packages/jenkins_jobs/local_yaml.py", line 569, in load
    return yaml.load(stream, functools.partial(LocalLoader, **kwargs))
  File "/usr/local/lib/python2.7/site-packages/yaml/__init__.py", line 71, in load
    return loader.get_single_data()
  File "/usr/local/lib/python2.7/site-packages/yaml/constructor.py", line 37, in get_single_data
    node = self.get_single_node()
  File "/usr/local/lib/python2.7/site-packages/yaml/composer.py", line 36, in get_single_node
    document = self.compose_document()
  File "/usr/local/lib/python2.7/site-packages/jenkins_jobs/local_yaml.py", line 282, in compose_document
    node = self.compose_node(None, None)
  File "/usr/local/lib/python2.7/site-packages/yaml/composer.py", line 82, in compose_node
    node = self.compose_sequence_node(anchor)
  File "/usr/local/lib/python2.7/site-packages/yaml/composer.py", line 111, in compose_sequence_node
    node.value.append(self.compose_node(node, index))
  File "/usr/local/lib/python2.7/site-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/usr/local/lib/python2.7/site-packages/yaml/composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "/usr/local/lib/python2.7/site-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/usr/local/lib/python2.7/site-packages/yaml/composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "/usr/local/lib/python2.7/site-packages/yaml/composer.py", line 82, in compose_node
    node = self.compose_sequence_node(anchor)
  File "/usr/local/lib/python2.7/site-packages/yaml/composer.py", line 111, in compose_sequence_node
    node.value.append(self.compose_node(node, index))
  File "/usr/local/lib/python2.7/site-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/usr/local/lib/python2.7/site-packages/yaml/composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "/usr/local/lib/python2.7/site-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/usr/local/lib/python2.7/site-packages/yaml/composer.py", line 127, in compose_mapping_node
    while not self.check_event(MappingEndEvent):
  File "/usr/local/lib/python2.7/site-packages/yaml/parser.py", line 98, in check_event
    self.current_event = self.state()
  File "/usr/local/lib/python2.7/site-packages/yaml/parser.py", line 439, in parse_block_mapping_key
    "expected <block end>, but found %r" % token.id, token.start_mark)
yaml.parser.ParserError: while parsing a block mapping
  in "/home/jenkins/workspace/recreate-pipelines/jobs/integr8ly/ocp3/test-suites/fuse-test.yaml", line 43, column 11
expected <block end>, but found '<scalar>'
  in "/home/jenkins/workspace/recreate-pipelines/jobs/integr8ly/ocp3/test-suites/fuse-test.yaml", line 45, column 70
```