### PR TITLE
Revert "INTLY-5130 Added stage to browser-based-single-test jenkins p…

### DIFF
--- a/jobs/integr8ly/ocp3/test-suites/browser-based-single-test.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/browser-based-single-test.yaml
@@ -49,12 +49,6 @@
 
             node('cirhos_rhel7') {  
 
-                stage('oc login') {
-                      sh """
-                      oc login ${CLUSTER_URL} --insecure-skip-tls-verify=true -u ${ADMIN_USERNAME} -p ${ADMIN_PASSWORD} 
-                      """      
-                }
-
                 stage('Clone the testsuite') {
                     dir('integreatly-qe') {
                         git branch: BRANCH, url: REPOSITORY


### PR DESCRIPTION
This reverts commit 6fa814e755b7da328e049cf671d42cb15b46c88b.

## What
Added stage broke OSD4 nightly testing, as pipeline in PR is used by for both OCP3 testing and OSD4 testing, and both openshift versions require slightly different urls to login to. 

This PR will remove the change from the pipeline so it can instead be added in a before hook in the testsuite (eg https://gitlab.cee.redhat.com/integreatly-qe/integreatly-qe/merge_requests/363/diffs - similar PR for OCP3 test branch to follow)
