### PR TITLE
fix: update cr reference

### DIFF
--- a/jobs/integr8ly/ocp4/install/image-deploy/Jenkinsfile
+++ b/jobs/integr8ly/ocp4/install/image-deploy/Jenkinsfile
@@ -96,15 +96,15 @@ node('cirhos_rhel7') {
                     sh(
                         returnStdout: false,
                         script: """
-                            sed -i "s@SELF_SIGNED_CERTS@${selfSignedCerts}@" deploy/crds/examples/integreatly-installation-cr.yaml
-                            sed -i "s@INSTALLATION_NAME@${installationName}@" deploy/crds/examples/integreatly-installation-cr.yaml
-                            sed -i "s@INSTALLATION_TYPE@${INSTALLATION_TYPE}@" deploy/crds/examples/integreatly-installation-cr.yaml
-                            sed -i "s@INSTALLATION_PREFIX@${INSTALLATION_PREFIX}@" deploy/crds/examples/integreatly-installation-cr.yaml
-                            sed -i "s@USE_CLUSTER_STORAGE@${useClusterStorage}@" deploy/crds/examples/integreatly-installation-cr.yaml
+                            sed -i "s@SELF_SIGNED_CERTS@${selfSignedCerts}@" deploy/crds/examples/integreatly-rhmi-cr.yaml
+                            sed -i "s@INSTALLATION_NAME@${installationName}@" deploy/crds/examples/integreatly-rhmi-cr.yaml
+                            sed -i "s@INSTALLATION_TYPE@${INSTALLATION_TYPE}@" deploy/crds/examples/integreatly-rhmi-cr.yaml
+                            sed -i "s@INSTALLATION_PREFIX@${INSTALLATION_PREFIX}@" deploy/crds/examples/integreatly-rhmi-cr.yaml
+                            sed -i "s@USE_CLUSTER_STORAGE@${useClusterStorage}@" deploy/crds/examples/integreatly-rhmi-cr.yaml
                         """
                     )
 
-                    sh "oc create -f deploy/crds/examples/integreatly-installation-cr.yaml -n ${installationNamespace}"
+                    sh "oc create -f deploy/crds/examples/integreatly-rhmi-cr.yaml -n ${installationNamespace}"
                     sleep time: 2, unit: 'MINUTES'
                 }
             } // stage


### PR DESCRIPTION
## What
https://issues.redhat.com/browse/INTLY-5364
[filename of integreatly operator cr](https://github.com/integr8ly/integreatly-operator/blob/master/deploy/crds/examples/integreatly-rhmi-cr.yaml) we use for pipeline was updated, [breaking this pipeline](https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/openshift4-rhmi-image-deploy-install/105/console), thus this fix.
