### PR TITLE
replace sed commands with make command

### DIFF
--- a/jobs/integr8ly/ocp4/install/image-deploy/Jenkinsfile
+++ b/jobs/integr8ly/ocp4/install/image-deploy/Jenkinsfile
@@ -93,18 +93,8 @@ node('cirhos_rhel7') {
 
             stage ('Create Installation CR') {
                 dir('integreatly-operator') {
-                    sh(
-                        returnStdout: false,
-                        script: """
-                            sed -i "s@SELF_SIGNED_CERTS@${selfSignedCerts}@" deploy/crds/examples/integreatly-rhmi-cr.yaml
-                            sed -i "s@INSTALLATION_NAME@${installationName}@" deploy/crds/examples/integreatly-rhmi-cr.yaml
-                            sed -i "s@INSTALLATION_TYPE@${INSTALLATION_TYPE}@" deploy/crds/examples/integreatly-rhmi-cr.yaml
-                            sed -i "s@INSTALLATION_PREFIX@${INSTALLATION_PREFIX}@" deploy/crds/examples/integreatly-rhmi-cr.yaml
-                            sed -i "s@USE_CLUSTER_STORAGE@${useClusterStorage}@" deploy/crds/examples/integreatly-rhmi-cr.yaml
-                        """
-                    )
-
-                    sh "oc create -f deploy/crds/examples/integreatly-rhmi-cr.yaml -n ${installationNamespace}"
+                    sh "oc project ${installationNamespace}"
+                    sh "make deploy/integreatly-rhmi-cr.yml SELF_SIGNED_CERTS=${selfSignedCerts} INSTALLATION_NAME=${installationName} INSTALLATION_TYPE=${INSTALLATION_TYPE} INSTALLATION_PREFIX=${INSTALLATION_PREFIX} USE_CLUSTER_STORAGE=${useClusterStorage}"
                     sleep time: 2, unit: 'MINUTES'
                 }
             } // stage


### PR DESCRIPTION
## What
Updates pipelline to use `make` command for creation of CR. 

## Why
Current use of manual sed commands is brittle as pipeline will break if dummy cr file is updated, and has [broken pipeline recently](https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/openshift4-rhmi-image-deploy-install/108/console) for exactly this reason

## How
Use make command for CR creation as this will be maintained.