### PR TITLE
added sleep between install and tests to allow for all pods to come up

### DIFF
--- a/jobs/delorean/jenkinsfiles/1.0/cluster/openshift/integreatly/test/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/1.0/cluster/openshift/integreatly/test/Jenkinsfile
@@ -102,6 +102,13 @@ pipeline {
       } 
     }
 
+    stage('Sleep for 5 minutes after installation') {
+      steps {
+        echo "[INFO] Waiting 5 minutes after installation before running tests"
+        sleep time: 5, unit: 'MINUTES'
+      } 
+    }
+
     stage('Test Integreatly') {
       steps {
         echo "[INFO] Running Tests on Integreatly"


### PR DESCRIPTION
## What
If there is no sleep between installation and tests, smoke tests often fail due to pods not being ready yet: https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/installation-smoke-tests/1393/console - https://issues.redhat.com/browse/INTLY-6601

## Verification
Sleep introduction with other stages removed (to confirm that there is no bug introduced with the sleep) were executed here: https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/all/job/pp-delorean-test/2/console (1 minute sleep)
