### PR TITLE
Disable EWS 2.0 jobs.

### DIFF
--- a/jobs/delorean/2.0/ews/3scale/discovery.yaml
+++ b/jobs/delorean/2.0/ews/3scale/discovery.yaml
@@ -6,7 +6,7 @@
       <h2>Click <a href="https://github.com/integr8ly/ci-cd/tree/master/jobs/delorean/2.0/ews/3scale">here</a> to see the job definition on GitHub!</h2>
 
       <h3>This job gets triggered by <a href="https://brewweb.engineering.redhat.com/brew/packageinfo?packageID=74069">Brew Builds</a> on the UMB</h3>
-    disabled: false
+    disabled: true
     project-type: pipeline
 
     # Trigger responds to new builds of 3scale-operator-metadata-container

--- a/jobs/delorean/2.0/ews/amq-online/discovery.yaml
+++ b/jobs/delorean/2.0/ews/amq-online/discovery.yaml
@@ -6,7 +6,7 @@
       <h2>Click <a href="https://github.com/integr8ly/ci-cd/tree/master/jobs/delorean/2.0/ews/amq-online">here</a> to see the job definition on GitHub!</h2>
 
       <h3>This job gets triggered by <a href="https://brewweb.engineering.redhat.com/brew/packageinfo?packageID=74050">Brew Builds</a> on the UMB</h3>
-    disabled: false
+    disabled: true
     project-type: pipeline
 
     # Trigger responds to new builds of amq7-amq-online-1-controller-manager-operator-metadata-container

--- a/jobs/delorean/2.0/ews/fuse-online/discovery.yaml
+++ b/jobs/delorean/2.0/ews/fuse-online/discovery.yaml
@@ -6,7 +6,7 @@
       <h2>Click <a href="https://github.com/integr8ly/ci-cd/tree/master/jobs/delorean/2.0/ews/fuse-online">here</a> to see the job definition on GitHub!</h2>
 
       <h3>This job gets triggered by <a href="https://brewweb.engineering.redhat.com/brew/packageinfo?packageID=69209">Brew Builds</a> on the UMB</h3>
-    disabled: false
+    disabled: true
     project-type: pipeline
 
     # Trigger responds to new builds of fuse-online-operator-container


### PR DESCRIPTION
Jobs have now been migrated to https://master-jenkins-csb-intly.cloud.paas.psi.redhat.com

Merge after https://gitlab.cee.redhat.com/integreatly-qe/ci-cd/merge_requests/93 
