### PR TITLE
Disable Pipelines that use POC clusters

### DIFF
--- a/jobs/integr8ly/ocp3/delorean-testing-nightly-trigger.yaml
+++ b/jobs/integr8ly/ocp3/delorean-testing-nightly-trigger.yaml
@@ -6,7 +6,7 @@
     description: "Nightly pipeline trigger for Delorean testing."
     sandbox: false
     concurrent: false
-    disabled: false
+    disabled: true
     triggers:
       - timed: "H(0-10) 18 * * *"
     properties:

--- a/jobs/integr8ly/ocp3/test-suites/msb-integration-test.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/msb-integration-test.yaml
@@ -4,7 +4,7 @@
     display-name: 'Managed Service Broker Integration Test'
     project-type: pipeline
     concurrent: false
-    disabled: false
+    disabled: true
     triggers:
       - timed: "H(0-10) 23 * * *"
     properties:

--- a/jobs/integr8ly/ocp3/tower/tower-clean-uninstall.yaml
+++ b/jobs/integr8ly/ocp3/tower/tower-clean-uninstall.yaml
@@ -6,7 +6,7 @@
     project-type: pipeline
     sandbox: false
     concurrent: false
-    disabled: false
+    disabled: true
     properties:
       - build-discarder:
           num-to-keep: 20


### PR DESCRIPTION
## What

Disable all Pipelines that use POC clusters because we are not supporting them anymore

<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->
