### PR TITLE
Updating Jira query to avoid duplicate tickets

### DIFF
--- a/jobs/delorean/jenkinsfiles/1.0/ews/branch/ga/Jenkinsfile
+++ b/jobs/delorean/jenkinsfiles/1.0/ews/branch/ga/Jenkinsfile
@@ -10,7 +10,7 @@ import org.kohsuke.github.GitHub
 import org.kohsuke.github.GitHubBuilder
 
 def createJiraQuery(labels) {
-  String query = "project = INTLY AND status = Open"
+  String query = "project = INTLY AND (status != Closed OR status != Resolved OR status != Completed)"
 
   for (i = 0; i < labels.size(); i++) {
     def label = labels[i].replaceAll('"', "'")


### PR DESCRIPTION
## What
Updating Jira query to check for all states other than closed, resolved or completed.

Currently if a tickets state is anything other than 'Open' Delorean will create a new duplicate ticket on the support sheriff board, see below tickets as an example:

https://issues.redhat.com/browse/INTLY-9324
https://issues.redhat.com/browse/INTLY-9442
