### PR TITLE
commented out possibly redundant step to unblock 1.x nightly pipeline

### DIFF
--- a/jobs/openshift/cluster/integreatly/osd-cluster-integreatly-uninstall.yaml
+++ b/jobs/openshift/cluster/integreatly/osd-cluster-integreatly-uninstall.yaml
@@ -69,7 +69,7 @@
           stage("Delete leftover apiservices and CRDs") {
             sh '''
               oc login https://console.${clusterName}.openshift.com --token=${openShiftToken}
-              oc delete crd $(oc get crd | egrep 'aerogear|integreatly|enmasse|mobile' | awk '{print $1}') || true
+              # oc delete crd $(oc get crd | egrep 'aerogear|integreatly|enmasse|mobile' | awk '{print $1}') || true
               oc delete apiservices $(oc get apiservices | egrep 'aerogear|integreatly|enmasse|mobile' | awk '{print $1}') || true
             '''
           }


### PR DESCRIPTION
## What
https://issues.redhat.com/browse/INTLY-10223

## Verification:
Uninstall with this change was executed here: https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/OSD/job/osd-cluster-integreatly-uninstall/483/console followed by successful install: https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/OSD/job/osd-cluster-integreatly-install/385/console
