### PR TITLE
remove redundant all-tests-executor stages

### DIFF
--- a/jobs/integr8ly/ocp3/test-suites/all-tests-executor.yaml
+++ b/jobs/integr8ly/ocp3/test-suites/all-tests-executor.yaml
@@ -151,19 +151,13 @@
                         runTests('w2-test-executor')
                     } // stage
 
-                    stage ('CodeReady test') {
-                        runTests('codeready-tests')
-                    } // stage
-
                     stage ('SSO user creation test') {
                         runTests('sso-user-create-tests')
                     } // stage
 
                     stage ('Start Dashboards Browser Tests') {
-                        runSingleBrowserTest('tests/10_fuse/fuse-console-login.js')
                         runSingleBrowserTest('tests/20_apicurito/apicurito-console-login.js')
                         runSingleBrowserTest('tests/30_three_scale/three_scale-login.js')
-                        runSingleBrowserTest('tests/40_che/che-console-login.js')
                         runSingleBrowserTest('tests/50_enmasse/enmasse-console-login.js')
                         runSingleBrowserTest('tests/60_launcher/launcher-console-login.js')
                         runSingleBrowserTest('tests/70_sso_access/sso-console-access.js')


### PR DESCRIPTION
## What

Remove tests for unsupported products from pipeline: [JIRA](https://issues.redhat.com/browse/INTLY-10319)

## Why

Only AMQ, 3Scale, and SSO are now supported in RHMI, so redundant tests for non-supported components should be removed so they do not have to be maintained or run during release testing.

## How

Remove stages in all-tests-executor pipeline that runs tests related to CodeReady and Fuse.
